### PR TITLE
Switch readiness from first-write to first-read; add `firstReadCallBackConn`

### DIFF
--- a/adapter/outboundgroup/smart.go
+++ b/adapter/outboundgroup/smart.go
@@ -345,7 +345,7 @@ func (s *Smart) wrapConnWithMetric(c C.Conn, proxy C.Proxy, metadata *C.Metadata
 
 	start := time.Now()
 
-	wrappedConn := callback.NewFirstWriteCallBackConn(c, func(err error) {
+	wrappedConn := callback.NewFirstReadCallBackConn(c, func(err error) {
 		latency := time.Since(start).Milliseconds()
 		if err == nil {
 			s.onDialSuccess()

--- a/common/callback/read_callback.go
+++ b/common/callback/read_callback.go
@@ -1,0 +1,54 @@
+package callback
+
+import (
+	"sync/atomic"
+
+	"github.com/metacubex/mihomo/common/buf"
+	N "github.com/metacubex/mihomo/common/net"
+	C "github.com/metacubex/mihomo/constant"
+)
+
+type firstReadCallBackConn struct {
+	C.Conn
+	callback func(error)
+	read     atomic.Bool
+}
+
+func (c *firstReadCallBackConn) Read(b []byte) (n int, err error) {
+	defer func() {
+		if c.read.CompareAndSwap(false, true) {
+			c.callback(err)
+		}
+	}()
+	return c.Conn.Read(b)
+}
+
+func (c *firstReadCallBackConn) ReadBuffer(buffer *buf.Buffer) (err error) {
+	defer func() {
+		if c.read.CompareAndSwap(false, true) {
+			c.callback(err)
+		}
+	}()
+	return c.Conn.ReadBuffer(buffer)
+}
+
+func (c *firstReadCallBackConn) Upstream() any {
+	return c.Conn
+}
+
+func (c *firstReadCallBackConn) WriterReplaceable() bool {
+	return true
+}
+
+func (c *firstReadCallBackConn) ReaderReplaceable() bool {
+	return c.read.Load()
+}
+
+var _ N.ExtendedConn = (*firstReadCallBackConn)(nil)
+
+func NewFirstReadCallBackConn(c C.Conn, callback func(error)) C.Conn {
+	return &firstReadCallBackConn{
+		Conn:     c,
+		callback: callback,
+	}
+}


### PR DESCRIPTION
Summary:
- Introduces `firstReadCallBackConn` that fires exactly once on the first Read/ReadBuffer completion, passing any error.
- Replace first-write-based signaling with first-read to measure dial-to-first-byte latency and success/failure.
- Rationale: write only confirms enqueue to the kernel buffer; first read reflects actual peer responsiveness and handshake completion.
- Improves detection of read-path failures (e.g., RST/FIN, timeouts, TLS alerts) and yields more accurate availability metrics.
- Low risk: timing of the callback shifts to a more meaningful event; no change to UDP paths.
