### PR TITLE
fix: The `icon` and `hidden` options for smart group are not effective

### DIFF
--- a/adapter/outboundgroup/smart.go
+++ b/adapter/outboundgroup/smart.go
@@ -118,6 +118,8 @@ func NewSmart(option *GroupCommonOption, providers []provider.ProxyProvider, opt
 		GroupBase: NewGroupBase(GroupBaseOption{
 			Name:            option.Name,
 			Type:            C.Smart,
+			Hidden:          option.Hidden,
+			Icon:            option.Icon,
 			Filter:          option.Filter,
 			ExcludeFilter:   option.ExcludeFilter,
 			ExcludeType:     option.ExcludeType,


### PR DESCRIPTION

<img width="321" height="128" alt="image" src="https://github.com/user-attachments/assets/8ad59508-fcbf-41eb-bb51-dbebc93649fd" />
<img width="654" height="118" alt="image" src="https://github.com/user-attachments/assets/e005e1b3-79df-4790-b3ed-38bc3c0286a7" />
<img width="948" height="334" alt="image" src="https://github.com/user-attachments/assets/153f0347-9425-4791-a984-15b1d39ee85a" />
It seem that the `icon` and `hidden` options for smart group are not effective