### PR TITLE
增加代理协议权重，适配empty-fallback参数

### DIFF
--- a/adapter/outboundgroup/smart.go
+++ b/adapter/outboundgroup/smart.go
@@ -77,6 +77,7 @@ type Smart struct {
 	dataCollector          *lightgbm.DataCollector
 	weightModel            *lightgbm.WeightModel
 	policyPriority         []priorityRule
+	typePriority         map[string]float64
 	priorityCache          xsync.Map[string, float64]
 	sampleRate             float64
 	useLightGBM            bool
@@ -299,6 +300,9 @@ func (s *Smart) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, 
 	}
 
 	proxies, asnNumber := s.selectProxies(metadata, s.GetProxies(true))
+	if len(proxies) == 0 {
+		return s.EmptyFallback().DialContext(ctx, metadata)
+	}
 	return tryDial(proxies, asnNumber)
 }
 
@@ -306,6 +310,9 @@ func (s *Smart) ListenPacketContext(ctx context.Context, metadata *C.Metadata) (
 	var finalErr error
 
 	proxies, asnNumber := s.selectProxies(metadata, s.GetProxies(true))
+	if len(proxies) == 0 {
+		return s.EmptyFallback().ListenPacketContext(ctx, metadata)
+	}
 	limit := len(proxies)
 	if limit > maxSelected {
 		limit = maxSelected
@@ -361,7 +368,10 @@ func (s *Smart) Unwrap(metadata *C.Metadata, touch bool) C.Proxy {
 	proxies := s.GetProxies(touch)
 
 	if metadata == nil {
-		return proxies[0]
+		if len(proxies) > 0 {
+			return proxies[0]
+		}
+		return s.EmptyFallback()
 	}
 
 	if s.selected != "" {
@@ -373,7 +383,9 @@ func (s *Smart) Unwrap(metadata *C.Metadata, touch bool) C.Proxy {
 	}
 
 	proxies, _ = s.selectProxies(metadata, proxies)
-
+	if len(proxies) == 0 {
+		return s.EmptyFallback()
+	}
 	return proxies[0]
 }
 
@@ -476,6 +488,16 @@ func (s *Smart) MarshalJSON() ([]byte, error) {
 		}
 		fmt.Fprintf(&policyPriorityBuf, "%s:%.2f", rule.pattern, rule.factor)
 	}
+	
+	var typePriorityBuf strings.Builder
+	typeCount := 0
+	for t, f := range s.typePriority {
+		if typeCount > 0 {
+			typePriorityBuf.WriteByte(';')
+		}
+		fmt.Fprintf(&typePriorityBuf, "%s:%.2f", t, f)
+		typeCount++
+	}
 
 	return json.Marshal(map[string]any{
 		"type":            s.Type().String(),
@@ -542,7 +564,7 @@ func (s *Smart) filterProxies(metadata *C.Metadata, wildcardTarget string, names
 		return selected[:minCount]
 	}
 
-	hasPriority := len(s.policyPriority) > 0
+	hasPriority := len(s.policyPriority) > 0 || len(s.typePriority) > 0
 
 	type sortKey struct {
 		delay  uint16
@@ -648,12 +670,7 @@ func (s *Smart) filterProxies(metadata *C.Metadata, wildcardTarget string, names
 		}
 
 		if len(selected) == 0 {
-			for _, p := range fallbackAll {
-				selected = append(selected, p)
-				if len(selected) >= minCount {
-					break
-				}
-			}
+			return nil
 		}
 	}
 
@@ -1651,7 +1668,7 @@ func (s *Smart) StatusTest(proxy C.Proxy, host string) (uint16, bool, error) {
 }
 
 func (s *Smart) getPriorityFactor(proxyName string) float64 {
-	if len(s.policyPriority) == 0 {
+	if len(s.policyPriority) == 0 && len(s.typePriority) == 0 {
 		return 1.0
 	}
 	if v, ok := s.priorityCache.Load(proxyName); ok {
@@ -1667,6 +1684,21 @@ func (s *Smart) getPriorityFactor(proxyName string) float64 {
 		} else if strings.Contains(proxyName, rule.pattern) {
 			factor = rule.factor
 			break
+		}
+	}
+	if len(s.typePriority) > 0 {
+		var targetProxy C.Proxy
+		for _, p := range s.GetProxies(false) {
+			if p.Name() == proxyName {
+				targetProxy = p
+				break
+			}
+		}
+		if targetProxy != nil {
+			proxyType := strings.ToLower(targetProxy.Type().String())
+			if typeFactor, ok := s.typePriority[proxyType]; ok {
+				factor *= typeFactor
+			}
 		}
 	}
 	s.priorityCache.Store(proxyName, factor)
@@ -1774,12 +1806,54 @@ func smartWithPreferASN(preferASN bool) smartOption {
 	}
 }
 
+func smartWithTypePriority(typePriority string) smartOption {
+	return func(s *Smart) {
+		if s.typePriority == nil {
+			s.typePriority = make(map[string]float64)
+		}
+		pairs := strings.Split(typePriority, ";")
+		for _, pair := range pairs {
+			pair = strings.TrimSpace(pair)
+			if pair == "" {
+				continue
+			}
+			parts := strings.Split(pair, ":")
+			if len(parts) != 2 {
+				log.Warnln("[Smart] Invalid type-priority rule: [%s], must be in 'type:factor' format", pair)
+				continue
+			}
+			rawType := strings.ToLower(strings.TrimSpace(parts[0]))
+			switch rawType {
+			case "ss":
+				rawType = "shadowsocks"
+			case "ssr":
+				rawType = "shadowsocksr"
+			case "gost-relay":
+				rawType = "gostrelay"
+			}
+			factorStr := strings.TrimSpace(parts[1])
+			factor, err := strconv.ParseFloat(factorStr, 64)
+			if err != nil || factor <= 0 {
+				log.Warnln("[Smart] Invalid priority factor for type [%s]: %v", rawType, err)
+				continue
+			}
+			s.typePriority[rawType] = factor
+		}
+	}
+}
+
 func parseSmartOption(config map[string]any) []smartOption {
 	opts := []smartOption{}
 
 	if elm, ok := config["policy-priority"]; ok {
 		if policyPriority, ok := elm.(string); ok {
 			opts = append(opts, smartWithPolicyPriority(policyPriority))
+		}
+	}
+	
+	if elm, ok := config["type-priority"]; ok {
+		if typePriority, ok := elm.(string); ok {
+			opts = append(opts, smartWithTypePriority(typePriority))
 		}
 	}
 


### PR DESCRIPTION
写法示例

type-priority: 'ss:1.5;vless:1.2;vmess:0.8'


empty-fallback同mihomo用法

可在配置文件中指定smart策略组empty-fallback: REJECT/DIRECT等