### PR TITLE
增加代理协议权重，适配empty-fallback参数

### DIFF
--- a/adapter/outboundgroup/smart.go
+++ b/adapter/outboundgroup/smart.go
@@ -60,6 +60,7 @@ var (
 
 type SmartOption struct {
 	PolicyPriority string  `group:"policy-priority,omitempty"`
+	TypePriority   string  `group:"type-priority,omitempty"`
 	UseLightGBM    bool    `group:"uselightgbm,omitempty"`
 	CollectData    bool    `group:"collectdata,omitempty"`
 	SampleRate     float64 `group:"sample-rate,omitempty"`
@@ -83,6 +84,7 @@ type Smart struct {
 	dataCollector          *lightgbm.DataCollector
 	weightModel            *lightgbm.WeightModel
 	policyPriority         []priorityRule
+	typePriority         map[string]float64
 	priorityCache          xsync.Map[string, float64]
 	sampleRate             float64
 	useLightGBM            bool
@@ -142,6 +144,7 @@ func NewSmart(option GroupCommonOption, smartOption SmartOption, emptyFallback C
 		configName:           configName,
 		disableUDP:           option.DisableUDP,
 		policyPriority:       make([]priorityRule, 0),
+		typePriority:         make(map[string]float64),
 		sampleRate:           1,
 		useLightGBM:          smartOption.UseLightGBM,
 		collectData:          smartOption.CollectData,
@@ -154,6 +157,9 @@ func NewSmart(option GroupCommonOption, smartOption SmartOption, emptyFallback C
 
 	if smartOption.PolicyPriority != "" {
 		applyPolicyPriority(s, smartOption.PolicyPriority)
+	}
+	if smartOption.TypePriority != "" {
+		applyTypePriority(s, smartOption.TypePriority)
 	}
 
 	s.InitSmart()
@@ -310,15 +316,25 @@ func (s *Smart) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, 
 
 		return nil, finalErr
 	}
+	
+	allProxies := s.GetProxies(true)
+	if len(allProxies) == 0 {
+		return s.EmptyFallback().DialContext(ctx, metadata)
+	}
 
-	proxies, asnNumber := s.selectProxies(metadata, s.GetProxies(true))
+	proxies, asnNumber := s.selectProxies(metadata, allProxies)
 	return tryDial(proxies, asnNumber)
 }
 
 func (s *Smart) ListenPacketContext(ctx context.Context, metadata *C.Metadata) (pc C.PacketConn, err error) {
 	var finalErr error
 
-	proxies, asnNumber := s.selectProxies(metadata, s.GetProxies(true))
+	allProxies := s.GetProxies(true)
+	if len(allProxies) == 0 {
+		return s.EmptyFallback().ListenPacketContext(ctx, metadata)
+	}
+
+	proxies, asnNumber := s.selectProxies(metadata, allProxies)
 	limit := len(proxies)
 	if limit > maxSelected {
 		limit = maxSelected
@@ -372,6 +388,10 @@ func (s *Smart) ListenPacketContext(ctx context.Context, metadata *C.Metadata) (
 
 func (s *Smart) Unwrap(metadata *C.Metadata, touch bool) C.Proxy {
 	proxies := s.GetProxies(touch)
+
+	if len(proxies) == 0 {
+		return s.EmptyFallback()
+	}
 
 	if metadata == nil {
 		return proxies[0]
@@ -489,6 +509,16 @@ func (s *Smart) MarshalJSON() ([]byte, error) {
 		}
 		fmt.Fprintf(&policyPriorityBuf, "%s:%.2f", rule.pattern, rule.factor)
 	}
+	
+	var typePriorityBuf strings.Builder
+	typeCount := 0
+	for t, f := range s.typePriority {
+		if typeCount > 0 {
+			typePriorityBuf.WriteByte(';')
+		}
+		fmt.Fprintf(&typePriorityBuf, "%s:%.2f", t, f)
+		typeCount++
+	}
 
 	return json.Marshal(map[string]any{
 		"type":            s.Type().String(),
@@ -501,6 +531,7 @@ func (s *Smart) MarshalJSON() ([]byte, error) {
 		"icon":            s.Icon(),
 		"emptyFallback":   s.EmptyFallback().Name(),
 		"policy-priority": policyPriorityBuf.String(),
+		"type-priority":   typePriorityBuf.String(),
 		"useLightGBM":     s.useLightGBM,
 		"collectData":     s.collectData,
 		"sampleRate":      s.sampleRate,
@@ -555,7 +586,7 @@ func (s *Smart) filterProxies(metadata *C.Metadata, wildcardTarget string, names
 		return selected[:minCount]
 	}
 
-	hasPriority := len(s.policyPriority) > 0
+	hasPriority := len(s.policyPriority) > 0 || len(s.typePriority) > 0
 
 	type sortKey struct {
 		delay  uint16
@@ -1664,7 +1695,7 @@ func (s *Smart) StatusTest(proxy C.Proxy, host string) (uint16, bool, error) {
 }
 
 func (s *Smart) getPriorityFactor(proxyName string) float64 {
-	if len(s.policyPriority) == 0 {
+	if len(s.policyPriority) == 0 && len(s.typePriority) == 0 {
 		return 1.0
 	}
 	if v, ok := s.priorityCache.Load(proxyName); ok {
@@ -1680,6 +1711,21 @@ func (s *Smart) getPriorityFactor(proxyName string) float64 {
 		} else if strings.Contains(proxyName, rule.pattern) {
 			factor = rule.factor
 			break
+		}
+	}
+	if len(s.typePriority) > 0 {
+		var targetProxy C.Proxy
+		for _, p := range s.GetProxies(false) {
+			if p.Name() == proxyName {
+				targetProxy = p
+				break
+			}
+		}
+		if targetProxy != nil {
+			proxyType := strings.ToLower(targetProxy.Type().String())
+			if typeFactor, ok := s.typePriority[proxyType]; ok {
+				factor *= typeFactor
+			}
 		}
 	}
 	s.priorityCache.Store(proxyName, factor)
@@ -1754,6 +1800,40 @@ func applyPolicyPriority(s *Smart, policyPriority string) {
 		}
 
 		s.policyPriority = append(s.policyPriority, rule)
+	}
+}
+
+func applyTypePriority(s *Smart, typePriority string) {
+	if s.typePriority == nil {
+		s.typePriority = make(map[string]float64)
+	}
+	pairs := strings.Split(typePriority, ";")
+	for _, pair := range pairs {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		parts := strings.Split(pair, ":")
+		if len(parts) != 2 {
+			log.Warnln("[Smart] Invalid type-priority rule: [%s], must be in 'type:factor' format", pair)
+			continue
+		}
+		rawType := strings.ToLower(strings.TrimSpace(parts[0]))
+		switch rawType {
+		case "ss":
+			rawType = "shadowsocks"
+		case "ssr":
+			rawType = "shadowsocksr"
+		case "gost-relay":
+			rawType = "gostrelay"
+		}
+		factorStr := strings.TrimSpace(parts[1])
+		factor, err := strconv.ParseFloat(factorStr, 64)
+		if err != nil || factor <= 0 {
+			log.Warnln("[Smart] Invalid priority factor for type [%s]: %v", rawType, err)
+			continue
+		}
+		s.typePriority[rawType] = factor
 	}
 }
 


### PR DESCRIPTION
写法示例

type-priority: 'ss:1.5;vless:1.2;vmess:0.8'

empty-fallback同mihomo用法

可在配置文件中指定smart策略组empty-fallback: REJECT/DIRECT等