### PR TITLE
feat: add Smart sticky sessions

### DIFF
--- a/adapter/outboundgroup/smart.go
+++ b/adapter/outboundgroup/smart.go
@@ -21,8 +21,10 @@ import (
 	"github.com/dlclark/regexp2"
 	"github.com/metacubex/mihomo/common/atomic"
 	"github.com/metacubex/mihomo/common/callback"
-	"github.com/metacubex/mihomo/common/xsync"
+	"github.com/metacubex/mihomo/common/lru"
 	N "github.com/metacubex/mihomo/common/net"
+	"github.com/metacubex/mihomo/common/utils"
+	"github.com/metacubex/mihomo/common/xsync"
 	"github.com/metacubex/mihomo/component/geodata"
 	"github.com/metacubex/mihomo/component/mmdb"
 	"github.com/metacubex/mihomo/component/profile/cachefile"
@@ -50,9 +52,12 @@ const (
 
 	maxRetries               = 3
 	maxSelected              = 10
+	smartStickyCacheAge      = 10 * time.Minute
+	smartStickyCacheSize     = 1000
 
 	parallelDials            = 5
 	connectThreshold         = 5.0
+	smartStrategyStickySessions = "sticky-sessions"
 )
 
 var (
@@ -62,6 +67,7 @@ var (
 
 type SmartOption struct {
 	PolicyPriority string  `group:"policy-priority,omitempty"`
+	Strategy       string  `group:"strategy,omitempty"`
 	UseLightGBM    bool    `group:"uselightgbm,omitempty"`
 	CollectData    bool    `group:"collectdata,omitempty"`
 	SampleRate     float64 `group:"sample-rate,omitempty"`
@@ -78,6 +84,8 @@ type Smart struct {
 
 	configName             string
 	selected               string
+	strategy               string
+	stickyCache            *lru.LruCache[uint64, string]
 	testUrl                string
 	expectedStatus         string
 	disableUDP             bool
@@ -123,6 +131,13 @@ func NewSmart(option GroupCommonOption, smartOption SmartOption, emptyFallback C
 		option.URL = C.DefaultTestURL
 	}
 
+	strategy := strings.TrimSpace(smartOption.Strategy)
+	switch strategy {
+	case "", smartStrategyStickySessions:
+	default:
+		return nil, fmt.Errorf("%w: smart strategy %q", errStrategy, smartOption.Strategy)
+	}
+
 	configName := getConfigFilename()
 
 	s := &Smart{
@@ -142,12 +157,20 @@ func NewSmart(option GroupCommonOption, smartOption SmartOption, emptyFallback C
 		testUrl:              option.URL,
 		expectedStatus:       option.ExpectedStatus,
 		configName:           configName,
+		strategy:             strategy,
 		disableUDP:           option.DisableUDP,
 		policyPriority:       make([]priorityRule, 0),
 		sampleRate:           1,
 		useLightGBM:          smartOption.UseLightGBM,
 		collectData:          smartOption.CollectData,
 		preferASN:            smartOption.PreferASN,
+	}
+
+	if strategy == smartStrategyStickySessions {
+		s.stickyCache = lru.New[uint64, string](
+			lru.WithAge[uint64, string](int64(smartStickyCacheAge.Seconds())),
+			lru.WithSize[uint64, string](smartStickyCacheSize),
+		)
 	}
 
 	if smartOption.SampleRate > 0 && smartOption.SampleRate <= 1 {
@@ -302,12 +325,14 @@ func (s *Smart) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, 
 				finalErr = err
 			} else {
 				s.store.StoreUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.NetWork == C.UDP, []C.Proxy{p})
+				s.storeStickyProxy(metadata, p)
 				return s.WrapConnWithMetric(c, p, metadata, connectTime), nil
 			}
 		}
 
 		if len(proxies) == 1 {
 			s.store.DeleteUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.NetWork == C.UDP)
+			s.clearStickyProxy(metadata)
 		}
 
 		return nil, finalErr
@@ -360,11 +385,13 @@ func (s *Smart) ListenPacketContext(ctx context.Context, metadata *C.Metadata) (
 			}
 
 			s.store.StoreUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.NetWork == C.UDP, []C.Proxy{proxy})
+			s.storeStickyProxy(metadata, proxy)
 			return s.WrapPacketConnWithMetric(pc, proxy, metadata, connectTime), nil
 		}
 
 		if singleProxyRetry {
 			s.store.DeleteUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.NetWork == C.UDP)
+			s.clearStickyProxy(metadata)
 			break
 		}
 	}
@@ -432,7 +459,7 @@ func (s *Smart) WrapConnWithMetric(c C.Conn, proxy C.Proxy, metadata *C.Metadata
 
 func (s *Smart) WrapPacketConnWithMetric(pc C.PacketConn, proxy C.Proxy, metadata *C.Metadata, connectTime int64) C.PacketConn {
 	pc.AppendToChains(s)
-	
+
 	var udpLatency atomic.Int64
 
 	pc = callback.NewFirstReadCallBackPacketConn(pc, func(latency int64) {
@@ -516,6 +543,82 @@ func (s *Smart) Providers() []provider.ProxyProvider {
 
 func (s *Smart) Proxies() []C.Proxy {
 	return s.GetProxies(false)
+}
+
+func getSmartStickyKey(metadata *C.Metadata) uint64 {
+	if metadata == nil {
+		return utils.MapHash("")
+	}
+
+	src := ""
+	if metadata.SrcIP.IsValid() {
+		src = metadata.SrcIP.String()
+	}
+
+	dstIP := ""
+	if metadata.DstIP.IsValid() {
+		dstIP = metadata.DstIP.String()
+	}
+
+	target := smart.GetEffectiveTarget(metadata.Host, dstIP)
+	if target == "" {
+		target = metadata.SmartTarget
+	}
+
+	return utils.MapHash(src + "\x00" + target)
+}
+
+func (s *Smart) getStickyProxy(metadata *C.Metadata, wildcardTarget string, proxies []C.Proxy, isUDP bool) C.Proxy {
+	if s.strategy != smartStrategyStickySessions || s.stickyCache == nil || metadata == nil {
+		return nil
+	}
+
+	key := getSmartStickyKey(metadata)
+	proxyName, ok := s.stickyCache.Get(key)
+	if !ok || proxyName == "" {
+		return nil
+	}
+
+	blockedNodes := s.store.GetBlockedNodes(s.Name(), s.configName)
+	wtFailNodes, _, _, wtBlocked := s.store.GetHostStatus(s.Name(), s.configName, wildcardTarget)
+
+	for _, proxy := range proxies {
+		if proxy.Name() != proxyName {
+			continue
+		}
+		if blockedNodes[proxyName] {
+			break
+		}
+		if !wtBlocked && wtFailNodes[proxyName] {
+			break
+		}
+		if !proxy.AliveForTestUrl(s.testUrl) {
+			break
+		}
+		if isUDP && !proxy.SupportUDP() {
+			break
+		}
+		return proxy
+	}
+
+	s.clearStickyProxy(metadata)
+	return nil
+}
+
+func (s *Smart) storeStickyProxy(metadata *C.Metadata, proxy C.Proxy) {
+	if s.strategy != smartStrategyStickySessions || s.stickyCache == nil || metadata == nil || proxy == nil {
+		return
+	}
+
+	s.stickyCache.Set(getSmartStickyKey(metadata), proxy.Name())
+}
+
+func (s *Smart) clearStickyProxy(metadata *C.Metadata) {
+	if s.strategy != smartStrategyStickySessions || s.stickyCache == nil || metadata == nil {
+		return
+	}
+
+	s.stickyCache.Delete(getSmartStickyKey(metadata))
 }
 
 func (s *Smart) filterProxies(metadata *C.Metadata, wildcardTarget string, names []string, weights []float64, all []C.Proxy, minCount int, isUDP bool) []C.Proxy {
@@ -692,6 +795,11 @@ func (s *Smart) selectProxies(metadata *C.Metadata, proxies []C.Proxy) ([]C.Prox
 		}
 	}
 
+	isUDP := metadata.NetWork == C.UDP
+	if proxy := s.getStickyProxy(metadata, wildcardTarget, proxies, isUDP); proxy != nil {
+		return []C.Proxy{proxy}, asnNumber
+	}
+
 	trySelector := func(isUDP bool) ([]string, []float64) {
 		// 检查匹配缓存
 		if proxiesName := s.store.GetUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, isUDP); len(proxiesName) > 0 {
@@ -711,7 +819,6 @@ func (s *Smart) selectProxies(metadata *C.Metadata, proxies []C.Proxy) ([]C.Prox
 		return nil, nil
 	}
 
-	isUDP := metadata.NetWork == C.UDP
 	resultNames, resultWeights := trySelector(isUDP)
 	result := s.filterProxies(metadata, wildcardTarget, resultNames, resultWeights, proxies, maxSelected, isUDP)
 
@@ -1658,6 +1765,7 @@ func (s *Smart) findSameConnection(metadata *C.Metadata, proxyName, target, asnI
 	}
 
 	s.store.DeleteUnwrapResult(s.Name(), s.configName, target, asnInfo, isUDP)
+	s.clearStickyProxy(metadata)
 
 }
 

--- a/adapter/outboundgroup/smart_test.go
+++ b/adapter/outboundgroup/smart_test.go
@@ -1,0 +1,251 @@
+package outboundgroup
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/netip"
+	"testing"
+
+	"github.com/metacubex/mihomo/common/lru"
+	"github.com/metacubex/mihomo/common/utils"
+	"github.com/metacubex/mihomo/component/profile/cachefile"
+	C "github.com/metacubex/mihomo/constant"
+)
+
+func TestNewSmartRejectsUnsupportedStrategy(t *testing.T) {
+	_, err := NewSmart(GroupCommonOption{Name: "smart", URL: "https://example.com/generate_204"}, SmartOption{Strategy: "round-robin"}, nil, nil)
+	if err == nil {
+		t.Fatal("expected unsupported smart strategy error")
+	}
+}
+
+func TestNewSmartKeepsEmptyStrategyNonSticky(t *testing.T) {
+	s, err := NewSmart(GroupCommonOption{Name: "smart", URL: "https://example.com/generate_204"}, SmartOption{}, nil, nil)
+	if err != nil {
+		t.Fatalf("expected empty smart strategy to be accepted: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = s.Close()
+	})
+
+	if s.strategy != "" {
+		t.Fatalf("expected empty strategy, got %q", s.strategy)
+	}
+	if s.stickyCache != nil {
+		t.Fatal("empty strategy should not initialize sticky cache")
+	}
+}
+
+func TestSmartStickyKeyUsesSourceAndEffectiveDestination(t *testing.T) {
+	metadata := &C.Metadata{
+		SrcIP:       netip.MustParseAddr("192.0.2.10"),
+		DstIP:       netip.MustParseAddr("203.0.113.8"),
+		Host:        "chat.openai.com",
+		SmartTarget: "RuleSet [AI Suite]",
+	}
+
+	sameEffectiveTarget := metadata.Clone()
+	sameEffectiveTarget.SmartTarget = "RuleSet [Other Label]"
+
+	differentSource := metadata.Clone()
+	differentSource.SrcIP = netip.MustParseAddr("192.0.2.11")
+
+	differentHost := metadata.Clone()
+	differentHost.Host = "api.another-example.com"
+
+	key := getSmartStickyKey(metadata)
+	if key != getSmartStickyKey(sameEffectiveTarget) {
+		t.Fatal("expected sticky key to ignore broad SmartTarget labels when host/IP is available")
+	}
+	if key == getSmartStickyKey(differentSource) {
+		t.Fatal("expected sticky key to include source IP")
+	}
+	if key == getSmartStickyKey(differentHost) {
+		t.Fatal("expected sticky key to include effective destination")
+	}
+}
+
+func TestSmartStickySelectionReusesHealthyProxy(t *testing.T) {
+	s := newSmartStickyTestGroup()
+	metadata := smartStickyTestMetadata()
+	proxies := []C.Proxy{
+		newSmartTestProxy("proxy-a", true, true, 30),
+		newSmartTestProxy("proxy-b", true, true, 20),
+		newSmartTestProxy("proxy-c", true, true, 10),
+	}
+
+	s.stickyCache.Set(getSmartStickyKey(metadata), "proxy-b")
+
+	selected, _ := s.selectProxies(metadata, proxies)
+	if len(selected) != 1 {
+		t.Fatalf("expected one sticky proxy, got %d", len(selected))
+	}
+	if selected[0].Name() != "proxy-b" {
+		t.Fatalf("expected proxy-b, got %s", selected[0].Name())
+	}
+}
+
+func TestSmartStickySelectionDropsUnavailableProxy(t *testing.T) {
+	s := newSmartStickyTestGroup()
+	metadata := smartStickyTestMetadata()
+	proxies := []C.Proxy{
+		newSmartTestProxy("proxy-a", true, true, 30),
+		newSmartTestProxy("proxy-c", true, true, 10),
+	}
+
+	s.stickyCache.Set(getSmartStickyKey(metadata), "proxy-b")
+
+	selected, _ := s.selectProxies(metadata, proxies)
+	if len(selected) != len(proxies) {
+		t.Fatalf("expected fallback Smart candidates, got %d proxies", len(selected))
+	}
+	for _, proxy := range selected {
+		if proxy.Name() == "proxy-b" {
+			t.Fatal("unavailable sticky proxy should not be returned")
+		}
+	}
+}
+
+func TestSmartStoreStickyProxyWritesCache(t *testing.T) {
+	s := newSmartStickyTestGroup()
+	metadata := smartStickyTestMetadata()
+	proxy := newSmartTestProxy("proxy-b", true, true, 20)
+
+	s.storeStickyProxy(metadata, proxy)
+
+	proxyName, ok := s.stickyCache.Get(getSmartStickyKey(metadata))
+	if !ok {
+		t.Fatal("expected sticky proxy to be cached")
+	}
+	if proxyName != "proxy-b" {
+		t.Fatalf("expected proxy-b in sticky cache, got %s", proxyName)
+	}
+}
+
+func TestSmartClearStickyProxyDeletesCache(t *testing.T) {
+	s := newSmartStickyTestGroup()
+	metadata := smartStickyTestMetadata()
+
+	s.stickyCache.Set(getSmartStickyKey(metadata), "proxy-b")
+	s.clearStickyProxy(metadata)
+
+	if proxyName, ok := s.stickyCache.Get(getSmartStickyKey(metadata)); ok {
+		t.Fatalf("expected sticky cache entry to be cleared, got %s", proxyName)
+	}
+}
+
+func TestSmartDialContextClearsStickyOnSingleProxyFailure(t *testing.T) {
+	s := newSmartStickyTestGroup()
+	metadata := smartStickyTestMetadata()
+	proxy := newSmartTestProxy("proxy-b", true, true, 20)
+	proxy.dialErr = errors.New("dial failed")
+	s.providerProxies = []C.Proxy{proxy}
+
+	s.stickyCache.Set(getSmartStickyKey(metadata), proxy.Name())
+
+	_, err := s.DialContext(context.Background(), metadata)
+	if err == nil {
+		t.Fatal("expected dial failure")
+	}
+	if proxyName, ok := s.stickyCache.Get(getSmartStickyKey(metadata)); ok {
+		t.Fatalf("expected sticky cache entry to be cleared after failed single-proxy dial, got %s", proxyName)
+	}
+}
+
+func newSmartStickyTestGroup() *Smart {
+	return &Smart{
+		GroupBase: NewGroupBase(GroupBaseOption{
+			Name: "smart-test",
+			Type: C.Smart,
+		}),
+		store:       cachefile.GetSmartStore(),
+		configName:  "smart-test-config",
+		testUrl:     "https://example.com/generate_204",
+		strategy:    smartStrategyStickySessions,
+		stickyCache: lru.New[uint64, string](lru.WithAge[uint64, string](600), lru.WithSize[uint64, string](1000)),
+	}
+}
+
+func smartStickyTestMetadata() *C.Metadata {
+	return &C.Metadata{
+		NetWork:     C.TCP,
+		SrcIP:       netip.MustParseAddr("192.0.2.10"),
+		DstIP:       netip.MustParseAddr("203.0.113.8"),
+		Host:        "api.example.com",
+		SmartTarget: "RuleSet [AI Suite]",
+	}
+}
+
+type smartTestProxy struct {
+	name    string
+	alive   bool
+	udp     bool
+	delay   uint16
+	dialErr error
+}
+
+func newSmartTestProxy(name string, alive bool, udp bool, delay uint16) *smartTestProxy {
+	return &smartTestProxy{name: name, alive: alive, udp: udp, delay: delay}
+}
+
+func (p *smartTestProxy) Name() string { return p.name }
+
+func (p *smartTestProxy) Type() C.AdapterType { return C.Direct }
+
+func (p *smartTestProxy) Addr() string { return p.name }
+
+func (p *smartTestProxy) SupportUDP() bool { return p.udp }
+
+func (p *smartTestProxy) ProxyInfo() C.ProxyInfo { return C.ProxyInfo{} }
+
+func (p *smartTestProxy) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]string{"name": p.name})
+}
+
+func (p *smartTestProxy) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
+	if p.dialErr != nil {
+		return nil, p.dialErr
+	}
+	return nil, C.ErrNotSupport
+}
+
+func (p *smartTestProxy) ListenPacketContext(ctx context.Context, metadata *C.Metadata) (C.PacketConn, error) {
+	return nil, C.ErrNotSupport
+}
+
+func (p *smartTestProxy) SupportUOT() bool { return false }
+
+func (p *smartTestProxy) IsL3Protocol(metadata *C.Metadata) bool { return false }
+
+func (p *smartTestProxy) Unwrap(metadata *C.Metadata, touch bool) C.Proxy { return p }
+
+func (p *smartTestProxy) Close() error { return nil }
+
+func (p *smartTestProxy) Adapter() C.ProxyAdapter { return p }
+
+func (p *smartTestProxy) AliveForTestUrl(url string) bool { return p.alive }
+
+func (p *smartTestProxy) DelayHistory() []C.DelayHistory { return nil }
+
+func (p *smartTestProxy) DelayHistoryForTestUrl(url string) []C.DelayHistory { return nil }
+
+func (p *smartTestProxy) ExtraDelayHistories() map[string]C.ProxyState { return nil }
+
+func (p *smartTestProxy) LastDelayForTestUrl(url string) uint16 {
+	if !p.alive {
+		return 0xffff
+	}
+	if p.delay == 0 {
+		return 1
+	}
+	return p.delay
+}
+
+func (p *smartTestProxy) URLTest(ctx context.Context, url string, expectedStatus utils.IntRanges[uint16]) (uint16, error) {
+	return p.LastDelayForTestUrl(url), nil
+}
+
+func (p *smartTestProxy) StatusTest(ctx context.Context, url string) (uint16, bool, error) {
+	return 204, p.alive, nil
+}


### PR DESCRIPTION
## Dependency chain

This PR is part of a three-PR change set for Smart `strategy: sticky-sessions` support:

1. **OIX core support:** [vernesong/mihomo-oix#6](https://github.com/vernesong/mihomo-oix/pull/6)
2. **Matching non-OIX core support, this PR:** [vernesong/mihomo#10](https://github.com/vernesong/mihomo/pull/10)
3. **OpenClash LuCI/YAML wiring:** [vernesong/OpenClash#5198](https://github.com/vernesong/OpenClash/pull/5198)

This non-OIX core PR does not depend on the OpenClash PR to build or test. It is, however, a required core-side dependency for OpenClash users who select a non-OIX Smart-capable core and enable Smart sticky sessions. [vernesong/OpenClash#5198](https://github.com/vernesong/OpenClash/pull/5198) should only be considered functionally complete for non-OIX users after this PR, or an equivalent non-OIX core implementation, is merged and released.

The OIX core PR [vernesong/mihomo-oix#6](https://github.com/vernesong/mihomo-oix/pull/6) should stay behaviorally aligned with this PR so OpenClash exposes one consistent Smart strategy option across OIX and non-OIX cores.

Recommended merge/release order:

1. Merge/release core support: [vernesong/mihomo-oix#6](https://github.com/vernesong/mihomo-oix/pull/6) for OIX and this PR for non-OIX.
2. Merge [vernesong/OpenClash#5198](https://github.com/vernesong/OpenClash/pull/5198) after the supported cores can parse and enforce Smart `strategy: sticky-sessions`.

## Summary

Add explicit `strategy: sticky-sessions` support for Smart proxy groups.

This keeps the non-OIX Smart implementation aligned with the OIX core patch. OpenClash can only expose and generate YAML after the core accepts and enforces the option.

## Root cause

Investigation showed Smart groups can route the same service/domain through multiple nodes. This also happens on non-OIX Smart cores, which indicates the issue is Smart group semantics rather than an OIX-specific TLS failure. In current core code, `strategy` is parsed for `load-balance` only; Smart does not accept `strategy` and instead relies on SmartTarget/ASN/cache/weight selection.

## Design

- Add `Strategy string` to `SmartOption`.
- Accept empty strategy and `sticky-sessions`; reject unsupported Smart strategies.
- Preserve existing Smart behavior when strategy is empty.
- Enable a bounded 10 minute / 1000 entry sticky cache only for `sticky-sessions`.
- Key affinity by source IP plus effective destination host/IP instead of broad `SmartTarget` labels.
- Reuse cached proxies only when still healthy, present, not Smart-blocked, not host-failed, and UDP-capable when required.
- Store affinity after successful TCP/UDP dial and clear stale entries on invalid sticky hits.
- Clear sticky entries when the only selected proxy fails and Smart deletes the corresponding unwrap cache, so the next retry can choose a fresh candidate.

## Validation

- `go test ./adapter/outboundgroup -run 'TestNewSmartRejectsUnsupportedStrategy|TestNewSmartKeepsEmptyStrategyNonSticky|TestSmartSticky' -count=1`
- `go test ./adapter/outboundgroup ./component/smart/... -count=1`
