### PR TITLE
增加代理协议权重

### DIFF
--- a/adapter/outboundgroup/smart.go
+++ b/adapter/outboundgroup/smart.go
@@ -62,6 +62,7 @@ var (
 
 type SmartOption struct {
 	PolicyPriority string  `group:"policy-priority,omitempty"`
+	TypePriority   string  `group:"type-priority,omitempty"`
 	UseLightGBM    bool    `group:"uselightgbm,omitempty"`
 	CollectData    bool    `group:"collectdata,omitempty"`
 	SampleRate     float64 `group:"sample-rate,omitempty"`
@@ -85,6 +86,7 @@ type Smart struct {
 	dataCollector          *lightgbm.DataCollector
 	weightModel            *lightgbm.WeightModel
 	policyPriority         []priorityRule
+	typePriority           map[string]float64
 	priorityCache          xsync.Map[string, float64]
 	sampleRate             float64
 	useLightGBM            bool
@@ -144,6 +146,7 @@ func NewSmart(option GroupCommonOption, smartOption SmartOption, emptyFallback C
 		configName:           configName,
 		disableUDP:           option.DisableUDP,
 		policyPriority:       make([]priorityRule, 0),
+		typePriority:         make(map[string]float64),
 		sampleRate:           1,
 		useLightGBM:          smartOption.UseLightGBM,
 		collectData:          smartOption.CollectData,
@@ -156,6 +159,10 @@ func NewSmart(option GroupCommonOption, smartOption SmartOption, emptyFallback C
 
 	if smartOption.PolicyPriority != "" {
 		applyPolicyPriority(s, smartOption.PolicyPriority)
+	}
+	
+	if smartOption.TypePriority != "" {
+		applyTypePriority(s, smartOption.TypePriority)
 	}
 
 	s.InitSmart()
@@ -491,6 +498,16 @@ func (s *Smart) MarshalJSON() ([]byte, error) {
 		}
 		fmt.Fprintf(&policyPriorityBuf, "%s:%.2f", rule.pattern, rule.factor)
 	}
+	
+	var typePriorityBuf strings.Builder
+	typeCount := 0
+	for t, f := range s.typePriority {
+		if typeCount > 0 {
+			typePriorityBuf.WriteByte(';')
+		}
+		fmt.Fprintf(&typePriorityBuf, "%s:%.2f", t, f)
+		typeCount++
+	}
 
 	return json.Marshal(map[string]any{
 		"type":            s.Type().String(),
@@ -503,6 +520,7 @@ func (s *Smart) MarshalJSON() ([]byte, error) {
 		"icon":            s.Icon(),
 		"emptyFallback":   s.EmptyFallback().Name(),
 		"policy-priority": policyPriorityBuf.String(),
+		"type-priority":   typePriorityBuf.String(),
 		"useLightGBM":     s.useLightGBM,
 		"collectData":     s.collectData,
 		"sampleRate":      s.sampleRate,
@@ -557,7 +575,7 @@ func (s *Smart) filterProxies(metadata *C.Metadata, wildcardTarget string, names
 		return selected[:minCount]
 	}
 
-	hasPriority := len(s.policyPriority) > 0
+	hasPriority := len(s.policyPriority) > 0 || len(s.typePriority) > 0
 
 	type sortKey struct {
 		delay  uint16
@@ -1699,22 +1717,27 @@ func (s *Smart) StatusTest(proxy C.Proxy, host string) (uint16, bool, error) {
 }
 
 func (s *Smart) getPriorityFactor(proxyName string) float64 {
-	if len(s.policyPriority) == 0 {
+	if len(s.policyPriority) == 0 && len(s.typePriority) == 0 {
 		return 1.0
 	}
 	if v, ok := s.priorityCache.Load(proxyName); ok {
 		return v
 	}
 	factor := 1.0
-	for _, rule := range s.policyPriority {
-		if rule.isRegex && rule.regex != nil {
-			if matched, _ := rule.regex.MatchString(proxyName); matched {
-				factor = rule.factor
+	
+	if len(s.typePriority) > 0 {
+		var targetProxy C.Proxy
+		for _, p := range s.GetProxies(false) {
+			if p.Name() == proxyName {
+				targetProxy = p
 				break
 			}
-		} else if strings.Contains(proxyName, rule.pattern) {
-			factor = rule.factor
-			break
+		}
+		if targetProxy != nil {
+			proxyType := strings.ToLower(targetProxy.Type().String())
+			if typeFactor, ok := s.typePriority[proxyType]; ok {
+				factor *= typeFactor
+			}
 		}
 	}
 	s.priorityCache.Store(proxyName, factor)
@@ -1789,6 +1812,42 @@ func applyPolicyPriority(s *Smart, policyPriority string) {
 		}
 
 		s.policyPriority = append(s.policyPriority, rule)
+	}
+}
+
+func applyTypePriority(s *Smart, typePriority string) {
+	if s.typePriority == nil {
+		s.typePriority = make(map[string]float64)
+	}
+	pairs := strings.Split(typePriority, ";")
+	for _, pair := range pairs {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		parts := strings.Split(pair, ":")
+		if len(parts) != 2 {
+			log.Warnln("[Smart] Invalid type-priority rule: [%s], must be in 'type:factor' format", pair)
+			continue
+		}
+		rawType := strings.ToLower(strings.TrimSpace(parts[0]))
+		
+		switch rawType {
+		case "ss":
+			rawType = "shadowsocks"
+		case "ssr":
+			rawType = "shadowsocksr"
+		case "gost-relay":
+			rawType = "gostrelay"
+		}
+		
+		factorStr := strings.TrimSpace(parts[1])
+		factor, err := strconv.ParseFloat(factorStr, 64)
+		if err != nil || factor <= 0 {
+			log.Warnln("[Smart] Invalid priority factor for type [%s]: %v", rawType, err)
+			continue
+		}
+		s.typePriority[rawType] = factor
 	}
 }
 


### PR DESCRIPTION
写法示例

type-priority: 'ss:1.5;vless:1.2;vmess:0.8'

关于完善代理简称的映射，我的想法是只加入的必要的映射如  "ss" "shadowsocks"，同mihomo官方出站协议type字段对齐即可

<img width="1264" height="2780" alt="Screenshot_2026-07-03-04-39-01-11_33f34bf0029ca15359ebd43d4b95def2" src="https://github.com/user-attachments/assets/42837398-c599-4156-80a5-2588f32c3599" />

(mihomo官方的shadowsocks协议 type字段为 ss)


没必要添加额外的代理简称映射，这样方便用户修改(参考mihomo官方文档对应协议的type字段，也可以直接在下载的机场订阅文件中复制type字段)

