### PR TITLE
fix: 修复 Smart 组状态探测导致进程反复退出(StatusTest 缺少 DialContext)

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -324,18 +324,7 @@ func urlToMetadata(rawURL string) (addr C.Metadata, err error) {
 }
 
 func (p *Proxy) StatusTest(ctx context.Context, rawURL string) (status uint16, ok bool, err error) {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return 1, false, err
-	}
-	host := u.Hostname()
-	port := u.Port()
-	if port == "" {
-		port = "443"
-	}
-
-	addr := &C.Metadata{}
-	if err := addr.SetRemoteAddress(net.JoinHostPort(host, port)); err != nil {
+	if _, err = urlToMetadata(rawURL); err != nil {
 		return 1, false, err
 	}
 
@@ -350,6 +339,16 @@ func (p *Proxy) StatusTest(ctx context.Context, rawURL string) (status uint16, o
 		return 1, false, fmt.Errorf("failed to get TLS fingerprint: %s", preset.FingerprintName)
 	}
 
+	// Resolve the target per hop instead of pinning the one from rawURL: redirects
+	// may point at another host, and every hop has to be dialed through the proxy.
+	dialProxy := func(dialCtx context.Context, targetAddr string) (net.Conn, error) {
+		var metadata C.Metadata
+		if err := metadata.SetRemoteAddress(targetAddr); err != nil {
+			return nil, err
+		}
+		return p.DialContext(dialCtx, &metadata)
+	}
+
 	// force ForceAttemptHTTP2 to false and use BuildWebsocketHandshakeState to custom http1.1 type for clear status code detection
 	transport := &http.Transport{
 		MaxIdleConns:          100,
@@ -357,13 +356,24 @@ func (p *Proxy) StatusTest(ctx context.Context, rawURL string) (status uint16, o
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		ForceAttemptHTTP2:     false,
+		// DialContext is required even though the probe URL is https: on a redirect to
+		// a plain-http URL the Transport uses this hook, and when it is nil it silently
+		// falls back to its package-level zeroDialer, which resolves through
+		// net.DefaultResolver and trips the guard installed in main().
+		DialContext: func(dialCtx context.Context, network, targetAddr string) (net.Conn, error) {
+			return dialProxy(dialCtx, targetAddr)
+		},
 		DialTLSContext: func(dialCtx context.Context, network, targetAddr string) (net.Conn, error) {
-			rawConn, err := p.DialContext(dialCtx, addr)
+			serverName, _, splitErr := net.SplitHostPort(targetAddr)
+			if splitErr != nil {
+				return nil, splitErr
+			}
+			rawConn, err := dialProxy(dialCtx, targetAddr)
 			if err != nil {
 				return nil, err
 			}
 			uCfg := tls.UConfig(tlsConfig)
-			uCfg.ServerName = host
+			uCfg.ServerName = serverName
 			uConn := tls.UClient(rawConn, uCfg, fingerprint)
 			if err := tls.BuildWebsocketHandshakeState(uConn); err != nil {
 				_ = rawConn.Close()


### PR DESCRIPTION
> 原正文为英文,应反馈改为中文重写,并把原先只在评论里的**第二条触发路径**并入正文。

## 问题

`f35e8767`("chore: refine http status test",2026-07-24)之后的所有 Alpha 构建,只要使用 `type: smart` 代理组,**进程会反复自行退出**,由守护机制拉起后再次退出,无限循环。

实测数据(一台家用网关,59 个 smart 组):最初每 15~16 分钟一次;更新到 `653d388` 后为 **24.5 小时崩溃 53 次,约每 28 分钟一次、每天约 52 次**。

退出方式是 `main()` 里那个哨兵的 `os.Exit(2)`,所以**日志等级输出里没有任何线索**,配置也完全正常。唯一特征在 stderr:

```
panic: should never be called

goroutine NNNNN [running]:
main.main.func1(...)
	github.com/metacubex/mihomo/main.go:87 +0x65
net.(*Resolver).dial(...)
	net/lookup.go:696 +0x63
```

后面跟着全部 goroutine 的栈转储(单次约 11000 行,还会把日志环形缓冲冲掉)。注意这**不是真的 panic** —— `main()` 把 `net.DefaultResolver.Dial` 换成了"打印所有 goroutine 栈 + `os.Exit(2)`"的哨兵。

## 根因

`f35e8767` 删掉了 `Proxy.StatusTest` 中 `http.Transport` 的 `DialContext`,只保留 `DialTLSContext`:

```diff
 	transport := &http.Transport{
-		DialContext: func(dialCtx context.Context, network, targetAddr string) (net.Conn, error) {
-			return dialProxy(dialCtx, targetAddr)
-		},
 		MaxIdleConns:          100,
```

`Smart.StatusTest` 构造的探测 URL 恒为 `https://<host>/?z=<随机数>`,所以初始请求走 TLS 分支没问题。但该 client 的 `CheckRedirect` 允许跟 **3 跳**重定向:

```go
CheckRedirect: func(req *http.Request, via []*http.Request) error {
	if len(via) >= 3 {
		return http.ErrUseLastResponse
	}
	return nil
},
```

被探测主机一旦 302 到 `http://`(端口 80),该跳就改走 `DialContext` 分支 —— 而它是 nil,于是 `Transport.dial` **静默回落到 http 包的包级 `zeroDialer`**,用 Go 标准库解析器解析域名,正好撞上哨兵,进程当场退出。

栈里被拨号的地址是端口 80 的明文跳,而任何探测 URL 都不会直接请求 80 端口 —— 这本身就佐证了是重定向后的那一跳。

## 两条触发路径,都是无条件的

解析连续 12 次崩溃转储、沿 `created by ... in goroutine N` 逐层回溯到根,结果对半分:

| 路径 | 根源 | 占比 |
|---|---|---|
| A 定时 | `startTimedTask` → `checkHostStatus` → `Smart.StatusTest`(smart.go:1768) | 6 / 12 |
| B 流量 | `recordConnectionStats` → `checkNodeQuality` → `Smart.StatusTest`(smart.go:1686) | 6 / 12 |

**路径 A** 的首次延迟正好 15 分钟,进程每次都死在第一轮,永远活不到 30 分钟的周期定时器 —— 这就是"稳定 15 分钟循环"的由来。而且 `startTimedTask` 是 **per-group** 注册的(在 `smartInitOnce` 之外),smart 组越多越必现。

**路径 B** 由实时流量驱动,门槛很低 —— smart.go:1684:

```go
if downloadTotal < 0.03 && metadata.Host != "" && metadata.DstPort == 443 && !isUDP && metadata.Type != C.INNER {
	if now-wtLastCheck > 300 || now-wtLastFailure < 300 {
		status, ok, err := s.StatusTest(proxy, metadata.Host)
```

任何经过 smart 组的 443 连接,只要下载量小于约 0.03 MB,就可能对自己的目标主机发起探测并杀掉进程。**全新安装、空数据库同样会触发** —— 而且此时 `wtLastCheck`/`wtLastFailure` 取自同一存储、默认为 0,使 `now-0 > 300` 恒真,300 秒限流形同虚设,反而更频繁。

这也意味着**清空 cache.db 不能规避,反而更糟**。

## 复现条件

需要至少一个被探测主机的根路径会 302 到明文 http。实测两个,都是日常高频域名:

- `ifs.tanx.com` → `http://err.taobao.com/error1.html`(阿里广告/埋点,淘宝天猫及大量国内站点会加载)
- `odc.officeapps.live.com` → `http://www.office.com/`(Office 遥测)

`SmartOption` 只暴露 `policy-priority` 和 `uselightgbm`,两个调用点均无条件执行,**没有任何配置层面的规避方法**。

## 本 PR 的修改

1. **恢复 `DialContext`** —— 致命项。让包括明文 http 重定向目标在内的每一跳都经代理拨号,而不是回落到标准库拨号器。
2. **拨号目标与 TLS `ServerName` 改为按每跳的 `targetAddr` 取**,不再钉死 `rawURL` 解析出的 host。`f35e8767` 之后,跨域重定向会被拨到原始地址、并配上原始 SNI。
3. **前置校验复用 `urlToMetadata`** —— 它按 scheme 推导默认端口,而被替换掉的内联代码对 `http://` 的探测 URL 也硬编码 443。

## 验证

在 `880847d` 上应用本补丁后,`go build ./adapter/`、`go vet ./adapter/`、完整 `go build .` 均通过。

## 影响范围

包含 `f35e8767` 之后的所有 Alpha 构建。已确认 `880847d` 与 `653d388` 均受影响 —— `653d388` 只是上游 merge,未触及 `adapter/adapter.go`,该文件至今最新改动仍是 `f35e8767` 本身。
