### PR TITLE
fix(smart): treat target probe transport errors as failures

### DIFF
--- a/adapter/outboundgroup/smart.go
+++ b/adapter/outboundgroup/smart.go
@@ -1708,13 +1708,11 @@ func (s *Smart) checkNodeQuality(
 		var checked bool
 		if now - wtLastCheck > 300 || now - wtLastFailure < 300 {
 			checked = true
-			status, ok, err := s.StatusTest(proxy, metadata.Host)
-			if err == nil {
-				failure = !ok
-				if failure {
-					log.Debugln("[Smart] Connection Group: [%s] - Node: [%s] - Network: [%s] - Address: [%s] detected abnormal response [%d]...",
-						s.Name(), proxyName, networkType, addressDisplay, status)
-				}
+			status, ok, testErr := s.StatusTest(proxy, metadata.Host)
+			failure = isStatusTestFailure(ok, testErr)
+			if failure {
+				log.Debugln("[Smart] Connection Group: [%s] - Node: [%s] - Network: [%s] - Address: [%s] detected abnormal response [%d], error: [%v]...",
+					s.Name(), proxyName, networkType, addressDisplay, status, testErr)
 			}
 		}
 		if failure {
@@ -1731,6 +1729,10 @@ func (s *Smart) checkNodeQuality(
 	}
 
 	return newWeight, false, false, 0
+}
+
+func isStatusTestFailure(ok bool, err error) bool {
+	return err != nil || !ok
 }
 
 func (s *Smart) markNodeFailure(metadata *C.Metadata, proxyName string, isDegraded bool, checked bool, blockCode int64) bool {

--- a/adapter/outboundgroup/smart_test.go
+++ b/adapter/outboundgroup/smart_test.go
@@ -1,0 +1,28 @@
+package outboundgroup
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsStatusTestFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		ok   bool
+		err  error
+		want bool
+	}{
+		{name: "successful response", ok: true, want: false},
+		{name: "unexpected status", ok: false, want: true},
+		{name: "request error", err: errors.New("unexpected EOF"), want: true},
+		{name: "request error overrides status", ok: true, err: errors.New("timeout"), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStatusTestFailure(tt.ok, tt.err); got != tt.want {
+				t.Fatalf("isStatusTestFailure(%v, %v) = %v, want %v", tt.ok, tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Treat transport errors from a target-specific `StatusTest` as failures.
- Preserve healthy handling for successful checks and failure handling for unexpected status responses.
- Add table-driven regression tests covering success, unexpected status, EOF, and timeout.

## Why

When a low-download HTTPS connection triggers a target-specific recheck, the existing code only updates `failure` when the check returns no error. A timeout, EOF, or other transport error therefore leaves the node eligible for the same target.

This change makes transport errors participate in the existing per-target failure cache and node filtering, without changing the global health-check URL or globally blocking the node.

## Tests

- `go test ./adapter/outboundgroup ./component/smart/...`

## AI assistance

Investigation, patch preparation, and test generation were performed with assistance from OpenAI Codex. The changes were reviewed and submitted by @yt433.
