### PR TITLE
fix(smart): stop rapid proxy rotation on successful dials

### DIFF
--- a/adapter/outboundgroup/smart.go
+++ b/adapter/outboundgroup/smart.go
@@ -101,6 +101,7 @@ type Smart struct {
 	suppressStats          atomic.Bool
 	suppressCount          atomic.Int64
 	suppressLast           atomic.Int64
+	selectionCoordinator   smartSelectionCoordinator
 }
 
 type dialResult struct {
@@ -248,7 +249,7 @@ func (s *Smart) singleDialContext(ctx context.Context, proxy C.Proxy, metadata *
 		if tunnel.ShouldStopRetry(err) {
 			return nil, connectTime, err
 		}
-		if !errors.Is(err, context.Canceled) {
+		if shouldRecordSmartDialFailure(ctx, err) {
 			go s.recordConnectionStats(metadata, proxy, connectTime, 0, 0, 0, 0, 0, 0, nil, err)
 		}
 		return nil, connectTime, err
@@ -271,26 +272,88 @@ func (s *Smart) groupDialFailed(proxies []C.Proxy, err error) {
 	}
 }
 
+func (s *Smart) prepareDialSelection(ctx context.Context, metadata *C.Metadata) (smartDialSelection, error) {
+	allProxies := s.GetProxies(true)
+	proxies, asnNumber, state := s.selectProxiesWithState(metadata, allProxies, false)
+	selection := smartDialSelection{
+		proxies:       proxies,
+		asnNumber:     asnNumber,
+		persistWinner: true,
+	}
+
+	if state.fixed || (state.cacheHit && !state.cacheExpired && len(proxies) == 1) {
+		if len(proxies) == 0 {
+			return smartDialSelection{}, fmt.Errorf("smart selection has no available proxy for %s", metadata.SmartTarget)
+		}
+		return selection, nil
+	}
+
+	flight, leader := s.selectionCoordinator.begin(state.key)
+	if leader {
+		freshProxies, freshASN, _ := s.selectProxiesWithState(metadata, allProxies, true)
+		if len(freshProxies) == 0 {
+			err := fmt.Errorf("smart selection has no fresh proxy for %s", metadata.SmartTarget)
+			s.selectionCoordinator.finish(state.key, flight, "", err)
+			return smartDialSelection{}, err
+		}
+		log.Debugln("[Smart] Selection leader: group=[%s] target=[%s] candidates=%d stale=%t", s.Name(), metadata.SmartTarget, len(freshProxies), state.cacheHit)
+		return smartDialSelection{
+			proxies:       freshProxies,
+			asnNumber:     freshASN,
+			persistWinner: true,
+			flightKey:     state.key,
+			flight:        flight,
+			leader:        true,
+		}, nil
+	}
+
+	if state.cacheHit && len(proxies) > 0 {
+		log.Debugln("[Smart] Selection follower uses stale winner: group=[%s] target=[%s]", s.Name(), metadata.SmartTarget)
+		return smartDialSelection{
+			proxies:       proxies[:1],
+			asnNumber:     asnNumber,
+			persistWinner: false,
+		}, nil
+	}
+
+	winner, err := flight.wait(ctx)
+	if err != nil {
+		return smartDialSelection{}, fmt.Errorf("smart selection wait failed for %s: %w", metadata.SmartTarget, err)
+	}
+	proxy, err := findSmartProxyByName(allProxies, winner)
+	if err != nil {
+		return smartDialSelection{}, err
+	}
+	log.Debugln("[Smart] Selection follower uses published winner: group=[%s] target=[%s] node=[%s]", s.Name(), metadata.SmartTarget, winner)
+	return smartDialSelection{
+		proxies:       []C.Proxy{proxy},
+		asnNumber:     asnNumber,
+		persistWinner: false,
+	}, nil
+}
+
+func (s *Smart) finishDialSelection(selection smartDialSelection, winner string, err error) {
+	if !selection.leader {
+		return
+	}
+	if err == nil {
+		log.Debugln("[Smart] Selection winner published: group=[%s] node=[%s]", s.Name(), winner)
+	} else {
+		log.Debugln("[Smart] Selection leader failed: group=[%s] error=[%s]", s.Name(), err)
+	}
+	s.selectionCoordinator.finish(selection.flightKey, selection.flight, winner, err)
+}
+
 func (s *Smart) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	getBatch := func(proxies []C.Proxy, i int) ([]C.Proxy, time.Duration) {
+	getBatch := func(proxies []C.Proxy, i int, leader bool) ([]C.Proxy, time.Duration) {
 		var batch []C.Proxy
 		var historyConnectTime int64
 		var timeout time.Duration
-		if len(proxies) == 1 {
-			batch = proxies[0:1]
-		} else if i == 0 {
-			batch = proxies[0:1]
-		} else {
-			begin := 1 + (i-1) * parallelDials
-			if begin >= len(proxies) {
-				return nil, 0
-			}
-			end := begin + parallelDials
-			if end > len(proxies) {
-				end = len(proxies)
-			}
-			batch = proxies[begin:end]
+		begin, end := smartDialBatchBounds(len(proxies), i, leader)
+		if begin == end {
+			return nil, 0
 		}
+		batch = proxies[begin:end]
 
 		for _, p := range batch {
 			hct := s.getHistoryConnectStats(metadata, p)
@@ -310,10 +373,12 @@ func (s *Smart) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, 
 		return batch, timeout
 	}
 
-	tryDial := func(proxies []C.Proxy, asnNumber string) (C.Conn, error) {
+	tryDial := func(selection smartDialSelection) (C.Conn, string, error) {
+		proxies := selection.proxies
+		asnNumber := selection.asnNumber
 		var finalErr error
 		for i := 0; i < maxRetries; i++ {
-			batch, timeout := getBatch(proxies, i)
+			batch, timeout := getBatch(proxies, i, selection.leader)
 			if len(batch) == 0 {
 				break
 			}
@@ -325,32 +390,48 @@ func (s *Smart) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, 
 
 			if err != nil {
 				if tunnel.ShouldStopRetry(err) {
-					return nil, err
+					return nil, "", err
 				}
 				finalErr = err
 			} else {
-				s.store.StoreUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.WildcardTarget, []C.Proxy{p})
+				if selection.persistWinner {
+					s.store.StoreUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.WildcardTarget, []C.Proxy{p})
+				}
 				s.onDialSuccess()
-				return s.WrapConnWithMetric(c, p, metadata, connectTime), nil
+				return s.WrapConnWithMetric(c, p, metadata, connectTime), p.Name(), nil
 			}
 		}
 
-		s.store.DeleteUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.WildcardTarget)
-
 		s.groupDialFailed(proxies, finalErr)
 
-		return nil, finalErr
+		if finalErr == nil {
+			finalErr = fmt.Errorf("smart selection has no dial candidate for %s", metadata.SmartTarget)
+		}
+		return nil, "", finalErr
 	}
 
-	proxies, asnNumber := s.selectProxies(metadata, s.GetProxies(true))
-
-	return tryDial(proxies, asnNumber)
+	selection, err := s.prepareDialSelection(ctx, metadata)
+	if err != nil {
+		return nil, err
+	}
+	conn, winner, err := tryDial(selection)
+	s.finishDialSelection(selection, winner, err)
+	return conn, err
 }
 
 func (s *Smart) ListenPacketContext(ctx context.Context, metadata *C.Metadata) (pc C.PacketConn, err error) {
 	var finalErr error
 
-	proxies, asnNumber := s.selectProxies(metadata, s.GetProxies(true))
+	selection, err := s.prepareDialSelection(ctx, metadata)
+	if err != nil {
+		return nil, err
+	}
+	proxies := selection.proxies
+	asnNumber := selection.asnNumber
+	winner := ""
+	defer func() {
+		s.finishDialSelection(selection, winner, err)
+	}()
 
 	limit := len(proxies)
 	if limit > maxSelected {
@@ -390,8 +471,11 @@ func (s *Smart) ListenPacketContext(ctx context.Context, metadata *C.Metadata) (
 				continue
 			}
 
-			s.store.StoreUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.WildcardTarget, []C.Proxy{proxy})
+			if selection.persistWinner {
+				s.store.StoreUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.WildcardTarget, []C.Proxy{proxy})
+			}
 			s.onDialSuccess()
+			winner = proxy.Name()
 			return s.WrapPacketConnWithMetric(pc, proxy, metadata, connectTime), nil
 		}
 
@@ -400,10 +484,11 @@ func (s *Smart) ListenPacketContext(ctx context.Context, metadata *C.Metadata) (
 		}
 	}
 
-	s.store.DeleteUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.WildcardTarget)
-
 	s.groupDialFailed(proxies, finalErr)
 
+	if finalErr == nil {
+		finalErr = fmt.Errorf("smart selection has no packet candidate for %s", metadata.SmartTarget)
+	}
 	return nil, finalErr
 }
 
@@ -742,7 +827,7 @@ func (s *Smart) filterProxies(metadata *C.Metadata, wildcardTarget string, names
 }
 
 // node selection
-func (s *Smart) selectProxies(metadata *C.Metadata, proxies []C.Proxy) ([]C.Proxy, string) {
+func (s *Smart) selectProxiesWithState(metadata *C.Metadata, proxies []C.Proxy, fresh bool) ([]C.Proxy, string, smartProxySelectionState) {
 	// attach ASN info
 	asnNumber := s.getASNCode(metadata)
 	wildcardTarget := smart.GetEffectiveTarget(metadata.Host, metadata.DstIP.String())
@@ -750,11 +835,15 @@ func (s *Smart) selectProxies(metadata *C.Metadata, proxies []C.Proxy) ([]C.Prox
 	if metadata.SmartTarget == "" {
 		metadata.SmartTarget = wildcardTarget
 	}
+	state := smartProxySelectionState{
+		key: smartSelectionFlightKey(s.configName, s.Name(), metadata.SmartTarget),
+	}
 
 	if s.selected != "" {
 		for _, p := range proxies {
 			if p.Name() == s.selected {
-				return []C.Proxy{p}, asnNumber
+				state.fixed = true
+				return []C.Proxy{p}, asnNumber, state
 			}
 		}
 	}
@@ -770,44 +859,31 @@ func (s *Smart) selectProxies(metadata *C.Metadata, proxies []C.Proxy) ([]C.Prox
 		return nil, nil
 	}
 
-	// asynchronously update expired cache (stale-while-revalidate)
-	refreshUnwrapCache := func(isUDP bool) {
-		names, _ := computeFreshNodes(isUDP)
-		if len(names) == 0 {
-			return
-		}
-		allProxies := s.GetProxies(true)
-		proxyByName := make(map[string]C.Proxy, len(allProxies))
-		for _, p := range allProxies {
-			proxyByName[p.Name()] = p
-		}
-		resultProxies := make([]C.Proxy, 0, len(names))
-		for _, name := range names {
-			if p, ok := proxyByName[name]; ok {
-				resultProxies = append(resultProxies, p)
-			}
-		}
-		if len(resultProxies) > 0 {
-			s.store.StoreUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.WildcardTarget, resultProxies)
-		}
-	}
-
 	trySelector := func(isUDP bool) ([]string, []float64) {
 		// check the unwrap cache
-		if proxiesName, expired := s.store.GetUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.WildcardTarget); len(proxiesName) > 0 {
-			if expired {
-				go refreshUnwrapCache(isUDP)
+		if !fresh {
+			if proxiesName, expired := s.store.GetUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.WildcardTarget); len(proxiesName) > 0 {
+				state.cacheHit = true
+				state.cacheExpired = expired
+				return proxiesName, nil
 			}
-			return proxiesName, nil
 		}
-		return computeFreshNodes(isUDP)
+		if proxiesName, weights := computeFreshNodes(isUDP); len(proxiesName) > 0 {
+			return proxiesName, weights
+		}
+		return nil, nil
 	}
 
 	isUDP := metadata.NetWork == C.UDP
 	resultNames, resultWeights := trySelector(isUDP)
 	result := s.filterProxies(metadata, wildcardTarget, resultNames, resultWeights, proxies, maxSelected, isUDP)
 
-	return result, asnNumber
+	return result, asnNumber, state
+}
+
+func (s *Smart) selectProxies(metadata *C.Metadata, proxies []C.Proxy) ([]C.Proxy, string) {
+	selected, asnNumber, _ := s.selectProxiesWithState(metadata, proxies, false)
+	return selected, asnNumber
 }
 
 func (s *Smart) InitSmart() {
@@ -1742,7 +1818,7 @@ func (s *Smart) checkNodeQuality(
 			checked = true
 			status, ok, err := s.StatusTest(proxy, metadata.Host)
 			if err == nil {
-				failure = !ok
+				failure = !smartStatusProbeAccepted(status, ok)
 				if failure {
 					log.Debugln("[Smart] Connection Group: [%s] - Node: [%s] - Network: [%s] - Address: [%s] detected abnormal response [%d]...",
 						s.Name(), proxyName, networkType, addressDisplay, status)
@@ -1857,7 +1933,7 @@ func (s *Smart) checkHostStatus() {
 				}
 				status, okRes, err := s.StatusTest(p, it.host)
 				metadata := &C.Metadata{Host: it.host}
-				if err == nil && okRes {
+				if err == nil && smartStatusProbeAccepted(status, okRes) {
 					s.store.UpdateHostStatus(s.Name(), s.configName, it.wildcardTarget, metadata, it.nodeName, s.maxFailedTimes, s.hostFailLimit, false, true, 0)
 					log.Debugln("[Smart] Recover Group: [%s] - Node: [%s] for Host: [%s] with HTTP Status: [%d]", s.Name(), it.nodeName, it.host, status)
 				} else if err == nil {

--- a/adapter/outboundgroup/smart.go
+++ b/adapter/outboundgroup/smart.go
@@ -330,7 +330,6 @@ func (s *Smart) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, 
 				finalErr = err
 			} else {
 				s.store.StoreUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.WildcardTarget, []C.Proxy{p})
-				s.closeSameConnection(metadata, p.Name(), metadata.SmartTarget, asnNumber, false)
 				s.onDialSuccess()
 				return s.WrapConnWithMetric(c, p, metadata, connectTime), nil
 			}
@@ -392,7 +391,6 @@ func (s *Smart) ListenPacketContext(ctx context.Context, metadata *C.Metadata) (
 			}
 
 			s.store.StoreUnwrapResult(s.Name(), s.configName, metadata.SmartTarget, asnNumber, metadata.WildcardTarget, []C.Proxy{proxy})
-			s.closeSameConnection(metadata, proxy.Name(), metadata.SmartTarget, asnNumber, false)
 			s.onDialSuccess()
 			return s.WrapPacketConnWithMetric(pc, proxy, metadata, connectTime), nil
 		}

--- a/adapter/outboundgroup/smart.go
+++ b/adapter/outboundgroup/smart.go
@@ -102,6 +102,7 @@ type Smart struct {
 	suppressCount          atomic.Int64
 	suppressLast           atomic.Int64
 	selectionCoordinator   smartSelectionCoordinator
+	activeMonitor          smartActiveMonitor
 }
 
 type dialResult struct {
@@ -174,6 +175,7 @@ func NewSmart(option GroupCommonOption, smartOption SmartOption, emptyFallback C
 	}
 
 	s.InitSmart()
+	s.startActiveConnectionMonitor()
 
 	return s, nil
 }
@@ -524,6 +526,14 @@ func (s *Smart) WrapConnWithMetric(c C.Conn, proxy C.Proxy, metadata *C.Metadata
 	c.AppendToChains(s)
 
 	start := time.Now()
+	timing := newSmartConnectionTiming(
+		s.Name(),
+		proxy.Name(),
+		metadata.SmartTarget,
+		metadata.WildcardTarget,
+		time.Duration(connectTime)*time.Millisecond,
+		start,
+	)
 
 	var firstWriteErr atomic.TypedValue[error]
 	var firstReadErr atomic.TypedValue[error]
@@ -531,6 +541,7 @@ func (s *Smart) WrapConnWithMetric(c C.Conn, proxy C.Proxy, metadata *C.Metadata
 
 	if N.NeedHandshake(c) {
 		c = callback.NewFirstWriteCallBackConn(c, func(err error) {
+			timing.logEvent(timing.firstWriteEvent(time.Now(), err))
 			if err != nil {
 				firstWriteErr.Store(err)
 			}
@@ -538,21 +549,24 @@ func (s *Smart) WrapConnWithMetric(c C.Conn, proxy C.Proxy, metadata *C.Metadata
 	}
 
 	c = callback.NewFirstReadCallBackConn(c, func(err error) {
-		firstReadLatency.Store(time.Since(start).Milliseconds())
+		now := time.Now()
+		firstReadLatency.Store(now.Sub(start).Milliseconds())
+		timing.logEvent(timing.firstReadEvent(now, err))
 		if err != nil {
 			firstReadErr.Store(err)
 		}
 	})
+	c = s.monitorActiveConnection(c, proxy, metadata)
 
 	return s.registerClosureMetricsCallback(
 		c, proxy, metadata, connectTime,
-		&firstReadLatency, &firstReadErr, &firstWriteErr,
+		&firstReadLatency, &firstReadErr, &firstWriteErr, timing,
 	)
 }
 
 func (s *Smart) WrapPacketConnWithMetric(pc C.PacketConn, proxy C.Proxy, metadata *C.Metadata, connectTime int64) C.PacketConn {
 	pc.AppendToChains(s)
-	
+
 	var udpLatency atomic.Int64
 
 	pc = callback.NewFirstReadCallBackPacketConn(pc, func(latency int64) {
@@ -642,6 +656,9 @@ func (s *Smart) Proxies() []C.Proxy {
 func (s *Smart) filterProxies(metadata *C.Metadata, wildcardTarget string, names []string, weights []float64, all []C.Proxy, minCount int, isUDP bool) []C.Proxy {
 	blockedNodes := s.store.GetBlockedNodes(s.Name(), s.configName)
 	wtFailNodes, _, _, wtBlocked := s.store.GetHostStatus(s.Name(), s.configName, wildcardTarget, s.hostFailLimit, metadata.SmartTarget)
+	activeCooling := func(name string) bool {
+		return s.activeNodeCoolingDown(name, wildcardTarget, time.Now())
+	}
 
 	var proxyByName map[string]C.Proxy
 	if len(names) > 0 {
@@ -658,7 +675,7 @@ func (s *Smart) filterProxies(metadata *C.Metadata, wildcardTarget string, names
 	for i, name := range names {
 		checkNodeUsed[name] = true
 		proxy := proxyByName[name]
-		if proxy == nil || blockedNodes[name] || !proxy.AliveForTestUrl(s.testUrl) || (isUDP && !proxy.SupportUDP()) {
+		if proxy == nil || blockedNodes[name] || activeCooling(name) || !proxy.AliveForTestUrl(s.testUrl) || (isUDP && !proxy.SupportUDP()) {
 			continue
 		}
 		w := 0.0
@@ -748,6 +765,9 @@ func (s *Smart) filterProxies(metadata *C.Metadata, wildcardTarget string, names
 		if blockedNodes[name] {
 			continue
 		}
+		if activeCooling(name) {
+			continue
+		}
 		if !p.AliveForTestUrl(s.testUrl) || (isUDP && !p.SupportUDP()) {
 			continue
 		}
@@ -794,6 +814,9 @@ func (s *Smart) filterProxies(metadata *C.Metadata, wildcardTarget string, names
 	if len(selected) == 0 {
 		fallbackAll := defaultSort(slices.Clone(all))
 		for _, p := range fallbackAll {
+			if activeCooling(p.Name()) {
+				continue
+			}
 			if (wtFailNodes[p.Name()] == 0 || (wtBlocked && wtFailNodes[p.Name()] != 1)) && p.AliveForTestUrl(s.testUrl) && (!isUDP || p.SupportUDP()) {
 				selected = append(selected, p)
 			}
@@ -804,6 +827,9 @@ func (s *Smart) filterProxies(metadata *C.Metadata, wildcardTarget string, names
 
 		if len(selected) == 0 {
 			for _, p := range fallbackAll {
+				if activeCooling(p.Name()) {
+					continue
+				}
 				if p.AliveForTestUrl(s.testUrl) {
 					selected = append(selected, p)
 				}
@@ -815,6 +841,9 @@ func (s *Smart) filterProxies(metadata *C.Metadata, wildcardTarget string, names
 
 		if len(selected) == 0 {
 			for _, p := range fallbackAll {
+				if activeCooling(p.Name()) {
+					continue
+				}
 				selected = append(selected, p)
 				if len(selected) >= minCount {
 					break
@@ -1460,11 +1489,11 @@ func (s *Smart) logConnectionStats(err error, record *smart.StatsRecord, metadat
 	}
 
 	log.Debugln("[Smart] Connection status: [%s], Updated weights: (Model: [%s], TCP: [%.4f], UDP: [%.4f], TCP ASN: [%.4f], UDP ASN: [%.4f], Base: [%.4f], Priority: [%.2f]) "+
-		"For (Group: [%s] - Node: [%s] - Network: [%s] - Address: [%s]) "+
+		"For (ID: [%s] - Group: [%s] - Node: [%s] - Network: [%s] - Address: [%s]) "+
 		"- Current: (Connect: [%s], Latency: [%s], LossRate: [%.2f%%], Up: [%s], Down: [%s], Max Up Speed: [%s], Max Down Speed: [%s], Duration: [%s]) "+
 		"- History: (Success: [%d], Failure: [%d], EMA Connect: [%s], EMA Latency: [%s], Cumul LossRate: [%.2f%%], Total Up: [%s], Total Down: [%s], Max Up Speed: [%s], Max Down Speed: [%s], Avg Duration: [%s])",
 		statusStr, weightSource, record.Weights[smart.WeightTypeTCP], record.Weights[smart.WeightTypeUDP], tcpAsnWeight, udpAsnWeight, baseWeight, priorityFactor,
-		s.Name(), proxyName, metadata.NetWork.String(), addressDisplay,
+		metadata.UUID, s.Name(), proxyName, metadata.NetWork.String(), addressDisplay,
 		formatTimeUnit(float64(connectTime)),
 		formatTimeUnit(float64(latency)),
 		lossRate*100,
@@ -1670,7 +1699,7 @@ func (s *Smart) recordConnectionStats(metadata *C.Metadata, proxy C.Proxy,
 
 	// block node for the specific domain/IP (wildcardTarget + SmartTarget two-level records)
 	failedBlock := s.markNodeFailure(metadata, proxyName, isDegraded, checked, blockCode)
-	
+
 	if isDegraded || failedBlock {
 		s.closeSameConnection(metadata, proxyName, target, asnNumber, true)
 	}
@@ -1701,7 +1730,7 @@ func (s *Smart) recordConnectionStats(metadata *C.Metadata, proxy C.Proxy,
 		connectTime, latency, uploadTotalMB, downloadTotalMB, maxUploadRateKB, maxDownloadRateKB, connectionDuration, asnNumber, ModelPredicted, lossRate, cumulLossRate)
 }
 
-func (s *Smart) registerClosureMetricsCallback(c C.Conn, proxy C.Proxy, metadata *C.Metadata, connectTime int64, firstReadLatency *atomic.Int64, firstReadErr *atomic.TypedValue[error], firstWriteErr *atomic.TypedValue[error]) C.Conn {
+func (s *Smart) registerClosureMetricsCallback(c C.Conn, proxy C.Proxy, metadata *C.Metadata, connectTime int64, firstReadLatency *atomic.Int64, firstReadErr *atomic.TypedValue[error], firstWriteErr *atomic.TypedValue[error], timing *smartConnectionTiming) C.Conn {
 	return callback.NewCloseCallbackConn(c, func() {
 		tracker := statistic.DefaultManager.Get(metadata.UUID)
 		if tracker != nil {
@@ -1711,6 +1740,7 @@ func (s *Smart) registerClosureMetricsCallback(c C.Conn, proxy C.Proxy, metadata
 			connectionDuration := time.Since(info.Start).Milliseconds()
 			maxUploadRate := info.MaxUploadRate.Load()
 			maxDownloadRate := info.MaxDownloadRate.Load()
+			timing.logClose(time.Now(), metadata.UUID, connectionDuration, uploadTotal, downloadTotal)
 
 			latency := firstReadLatency.Load()
 			readErr := firstReadErr.Load()

--- a/adapter/outboundgroup/smart_active_monitor.go
+++ b/adapter/outboundgroup/smart_active_monitor.go
@@ -1,0 +1,349 @@
+package outboundgroup
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	C "github.com/metacubex/mihomo/constant"
+	"github.com/metacubex/mihomo/log"
+	"github.com/metacubex/mihomo/tunnel"
+	"github.com/metacubex/mihomo/tunnel/statistic"
+)
+
+const (
+	smartMonitorInterval           = time.Second
+	smartMonitorEvidenceWindow     = 2 * time.Minute
+	smartMonitorCooldown           = 5 * time.Minute
+	smartMonitorNoResponseAfter    = 5 * time.Second
+	smartMonitorSlowResponseAfter  = 2500 * time.Millisecond
+	smartMonitorRequestSeparation  = 500 * time.Millisecond
+	smartMonitorMinUploadBytes     = 128
+	smartMonitorMinDownloadBytes   = 16 * 1024
+	smartMonitorSlowBytesPerSecond = 16 * 1024
+)
+
+type smartActiveMonitor struct {
+	mu          sync.Mutex
+	connections map[*smartMonitoredConn]struct{}
+	evidence    map[string]smartDegradationEvidence
+}
+
+type smartDegradationEvidence struct {
+	connection     *smartMonitoredConn
+	observation    uint64
+	reason         string
+	observedAt     time.Time
+	confirmedUntil time.Time
+}
+
+type smartMonitorSignal struct {
+	reason        string
+	observation   uint64
+	duration      time.Duration
+	uploadBytes   int64
+	downloadBytes int64
+}
+
+type smartMonitoredConn struct {
+	C.Conn
+	smart          *Smart
+	proxyName      string
+	target         string
+	wildcardTarget string
+	metadata       *C.Metadata
+	tracker        statistic.Tracker
+
+	mu               sync.Mutex
+	closed           bool
+	observing        bool
+	signaled         bool
+	observation      uint64
+	startedAt        time.Time
+	lastReadAt       time.Time
+	uploadBaseline   int64
+	downloadBaseline int64
+	uploadTotal      int64
+	downloadTotal    int64
+}
+
+func (s *Smart) startActiveConnectionMonitor() {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		waitTicker := time.NewTicker(100 * time.Millisecond)
+		defer waitTicker.Stop()
+		for tunnel.Status() != tunnel.Running {
+			select {
+			case <-waitTicker.C:
+			case <-s.ctx.Done():
+				return
+			}
+		}
+
+		ticker := time.NewTicker(smartMonitorInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case now := <-ticker.C:
+				s.sampleActiveConnections(now)
+			case <-s.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (s *Smart) monitorActiveConnection(conn C.Conn, proxy C.Proxy, metadata *C.Metadata) C.Conn {
+	if metadata == nil || metadata.NetWork != C.TCP || metadata.DstPort != 443 || metadata.Type == C.INNER || metadata.WildcardTarget == "" {
+		return conn
+	}
+
+	monitored := &smartMonitoredConn{
+		Conn:           conn,
+		smart:          s,
+		proxyName:      proxy.Name(),
+		target:         metadata.SmartTarget,
+		wildcardTarget: metadata.WildcardTarget,
+		metadata:       metadata,
+	}
+	s.activeMonitor.mu.Lock()
+	if s.activeMonitor.connections == nil {
+		s.activeMonitor.connections = make(map[*smartMonitoredConn]struct{})
+	}
+	s.activeMonitor.connections[monitored] = struct{}{}
+	s.activeMonitor.mu.Unlock()
+	return monitored
+}
+
+func (c *smartMonitoredConn) Close() error {
+	c.mu.Lock()
+	remove := !c.closed
+	if remove {
+		c.closed = true
+	}
+	c.mu.Unlock()
+	if remove {
+		c.smart.removeActiveConnection(c)
+	}
+	return c.Conn.Close()
+}
+
+func (c *smartMonitoredConn) ReaderReplaceable() bool {
+	return true
+}
+
+func (c *smartMonitoredConn) WriterReplaceable() bool {
+	return true
+}
+
+func (c *smartMonitoredConn) Upstream() any {
+	return c.Conn
+}
+
+func (c *smartMonitoredConn) observeTotals(uploadTotal, downloadTotal int64, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
+	previousDownloadTotal := c.downloadTotal
+	uploadDelta := uploadTotal - c.uploadTotal
+	downloadDelta := downloadTotal - c.downloadTotal
+	c.uploadTotal = uploadTotal
+	c.downloadTotal = downloadTotal
+	if downloadDelta > 0 {
+		c.lastReadAt = now
+	}
+	if uploadDelta <= 0 {
+		return
+	}
+	if !c.observing || c.signaled || (!c.lastReadAt.IsZero() && now.Sub(c.lastReadAt) >= smartMonitorRequestSeparation && downloadTotal > c.downloadBaseline) {
+		c.observation++
+		c.observing = true
+		c.signaled = false
+		c.startedAt = now
+		c.uploadBaseline = uploadTotal - uploadDelta
+		c.downloadBaseline = previousDownloadTotal
+	}
+}
+
+func (c *smartMonitoredConn) sample(now time.Time) (smartMonitorSignal, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed || !c.observing || c.signaled {
+		return smartMonitorSignal{}, false
+	}
+
+	duration := now.Sub(c.startedAt)
+	upload := c.uploadTotal - c.uploadBaseline
+	download := c.downloadTotal - c.downloadBaseline
+	if upload < smartMonitorMinUploadBytes {
+		return smartMonitorSignal{}, false
+	}
+
+	reason := ""
+	if download == 0 && duration >= smartMonitorNoResponseAfter {
+		reason = "no-response-after-write"
+	} else if download >= smartMonitorMinDownloadBytes && duration >= smartMonitorSlowResponseAfter {
+		rate := float64(download) / duration.Seconds()
+		if rate < smartMonitorSlowBytesPerSecond {
+			reason = "sustained-low-throughput"
+		} else {
+			c.observing = false
+			return smartMonitorSignal{}, false
+		}
+	}
+	if reason == "" {
+		return smartMonitorSignal{}, false
+	}
+
+	c.signaled = true
+	return smartMonitorSignal{
+		reason:        reason,
+		observation:   c.observation,
+		duration:      duration,
+		uploadBytes:   upload,
+		downloadBytes: download,
+	}, true
+}
+
+func (s *Smart) removeActiveConnection(conn *smartMonitoredConn) {
+	s.activeMonitor.mu.Lock()
+	delete(s.activeMonitor.connections, conn)
+	s.activeMonitor.mu.Unlock()
+}
+
+func (s *Smart) sampleActiveConnections(now time.Time) {
+	s.activeMonitor.mu.Lock()
+	connections := make([]*smartMonitoredConn, 0, len(s.activeMonitor.connections))
+	for conn := range s.activeMonitor.connections {
+		connections = append(connections, conn)
+	}
+	s.activeMonitor.mu.Unlock()
+
+	for _, conn := range connections {
+		tracker := s.findActiveTracker(conn)
+		if tracker == nil {
+			continue
+		}
+		info := tracker.Info()
+		conn.observeTotals(info.UploadTotal.Load(), info.DownloadTotal.Load(), now)
+		if signal, ok := conn.sample(now); ok {
+			s.handleActiveDegradation(conn, signal, now)
+		}
+	}
+}
+
+func (s *Smart) handleActiveDegradation(conn *smartMonitoredConn, signal smartMonitorSignal, now time.Time) {
+	if signal.reason != "sustained-low-throughput" {
+		log.Warnln("[SmartMonitor] Observed unanswered active connection without automatic action: group=[%s] node=[%s] wildcard=[%s] duration=[%s] upload=[%d] observation=[%d]",
+			s.Name(), conn.proxyName, conn.wildcardTarget, signal.duration, signal.uploadBytes, signal.observation)
+		return
+	}
+	key := conn.proxyName + "\x00" + conn.wildcardTarget
+	confirmed := s.recordActiveDegradationEvidence(key, conn, signal.observation, signal.reason, now)
+	if !confirmed {
+		log.Warnln("[SmartMonitor] Suspect active connection: group=[%s] node=[%s] wildcard=[%s] reason=[%s] duration=[%s] upload=[%d] download=[%d] observation=[%d]",
+			s.Name(), conn.proxyName, conn.wildcardTarget, signal.reason, signal.duration, signal.uploadBytes, signal.downloadBytes, signal.observation)
+		return
+	}
+
+	log.Warnln("[SmartMonitor] Confirmed active degradation: group=[%s] node=[%s] wildcard=[%s] reason=[%s] duration=[%s] upload=[%d] download=[%d] observation=[%d]",
+		s.Name(), conn.proxyName, conn.wildcardTarget, signal.reason, signal.duration, signal.uploadBytes, signal.downloadBytes, signal.observation)
+
+	s.store.DeleteUnwrapResult(s.Name(), s.configName, conn.target, "", conn.wildcardTarget)
+
+	tracker := s.findActiveTracker(conn)
+	if tracker == nil {
+		log.Warnln("[SmartMonitor] Unable to close confirmed degraded connection: group=[%s] node=[%s] wildcard=[%s] error=[tracker-not-found]",
+			s.Name(), conn.proxyName, conn.wildcardTarget)
+		return
+	}
+	tracker.Info().Metadata.SmartBlock = "degraded"
+	if err := tracker.Close(); err != nil {
+		log.Warnln("[SmartMonitor] Failed to close confirmed degraded connection: id=[%s] error=[%v]", tracker.ID(), err)
+	} else {
+		log.Warnln("[SmartMonitor] Closed confirmed degraded connection: id=[%s] group=[%s] node=[%s] wildcard=[%s]",
+			tracker.ID(), s.Name(), conn.proxyName, conn.wildcardTarget)
+	}
+}
+
+func (s *Smart) recordActiveDegradationEvidence(key string, conn *smartMonitoredConn, observation uint64, reason string, now time.Time) bool {
+	s.activeMonitor.mu.Lock()
+	defer s.activeMonitor.mu.Unlock()
+	if s.activeMonitor.evidence == nil {
+		s.activeMonitor.evidence = make(map[string]smartDegradationEvidence)
+	}
+	previous, found := s.activeMonitor.evidence[key]
+	if found && now.Before(previous.confirmedUntil) {
+		return false
+	}
+	withinWindow := found && now.Sub(previous.observedAt) <= smartMonitorEvidenceWindow
+	if withinWindow {
+		if previous.connection == conn || !previous.connection.isClosed() || previous.reason != "sustained-low-throughput" || reason != "sustained-low-throughput" {
+			return false
+		}
+		s.activeMonitor.evidence[key] = smartDegradationEvidence{confirmedUntil: now.Add(smartMonitorCooldown)}
+		return true
+	}
+	s.activeMonitor.evidence[key] = smartDegradationEvidence{
+		connection:  conn,
+		observation: observation,
+		reason:      reason,
+		observedAt:  now,
+	}
+	return false
+}
+
+func (c *smartMonitoredConn) isClosed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
+}
+
+func (s *Smart) activeNodeCoolingDown(proxyName, wildcardTarget string, now time.Time) bool {
+	key := proxyName + "\x00" + wildcardTarget
+	s.activeMonitor.mu.Lock()
+	defer s.activeMonitor.mu.Unlock()
+	evidence, found := s.activeMonitor.evidence[key]
+	if !found || evidence.confirmedUntil.IsZero() {
+		return false
+	}
+	if now.Before(evidence.confirmedUntil) {
+		return true
+	}
+	delete(s.activeMonitor.evidence, key)
+	return false
+}
+
+func (s *Smart) findActiveTracker(conn *smartMonitoredConn) statistic.Tracker {
+	conn.mu.Lock()
+	if conn.tracker != nil {
+		tracker := conn.tracker
+		conn.mu.Unlock()
+		return tracker
+	}
+	conn.mu.Unlock()
+
+	var matched statistic.Tracker
+	statistic.DefaultManager.RangeSmartTarget(conn.target, func(id string) bool {
+		tracker := statistic.DefaultManager.Get(id)
+		if tracker != nil && tracker.Info().Metadata == conn.metadata {
+			matched = tracker
+			return false
+		}
+		return true
+	})
+	if matched != nil {
+		conn.mu.Lock()
+		conn.tracker = matched
+		conn.mu.Unlock()
+	}
+	return matched
+}
+
+func (s smartMonitorSignal) String() string {
+	return fmt.Sprintf("%s duration=%s upload=%d download=%d observation=%d", s.reason, s.duration, s.uploadBytes, s.downloadBytes, s.observation)
+}

--- a/adapter/outboundgroup/smart_active_monitor_test.go
+++ b/adapter/outboundgroup/smart_active_monitor_test.go
@@ -1,0 +1,145 @@
+package outboundgroup
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	N "github.com/metacubex/mihomo/common/net"
+	C "github.com/metacubex/mihomo/constant"
+)
+
+type smartMonitorTestConn struct {
+	N.ExtendedConn
+}
+
+func (*smartMonitorTestConn) Chains() C.Chain               { return nil }
+func (*smartMonitorTestConn) ProviderChains() C.Chain       { return nil }
+func (*smartMonitorTestConn) AppendToChains(C.ProxyAdapter) {}
+func (*smartMonitorTestConn) RemoteDestination() string     { return "" }
+
+func TestSmartMonitoredConnPreservesRelayUnwrap(t *testing.T) {
+	upstreamReader, upstreamWriter := net.Pipe()
+	defer upstreamReader.Close()
+	defer upstreamWriter.Close()
+	base := N.NewExtendedConn(upstreamReader)
+	inner := &smartMonitorTestConn{ExtendedConn: base}
+	monitored := &smartMonitoredConn{Conn: inner}
+
+	if got := N.UnwrapReader(monitored); got != inner {
+		t.Fatalf("reader did not unwrap to base connection: %T", got)
+	}
+	if got := N.UnwrapWriter(monitored); got != inner {
+		t.Fatalf("writer did not unwrap to base connection: %T", got)
+	}
+}
+
+func TestSmartMonitoredConnNoResponseNeedsMeaningfulWrite(t *testing.T) {
+	start := time.Unix(100, 0)
+	conn := &smartMonitoredConn{}
+
+	conn.observeTotals(smartMonitorMinUploadBytes-1, 0, start)
+	if signal, ok := conn.sample(start.Add(smartMonitorNoResponseAfter)); ok {
+		t.Fatalf("tiny write produced signal: %s", signal)
+	}
+
+	conn.observeTotals(smartMonitorMinUploadBytes, 0, start.Add(time.Second))
+	signal, ok := conn.sample(start.Add(time.Second + smartMonitorNoResponseAfter))
+	if !ok || signal.reason != "no-response-after-write" {
+		t.Fatalf("meaningful unanswered write did not produce expected signal: ok=%v signal=%s", ok, signal)
+	}
+}
+
+func TestSmartMonitoredConnDistinguishesSlowAndHealthyTransfer(t *testing.T) {
+	start := time.Unix(200, 0)
+	slow := &smartMonitoredConn{}
+	slow.observeTotals(smartMonitorMinUploadBytes, 0, start)
+	slow.observeTotals(smartMonitorMinUploadBytes, smartMonitorMinDownloadBytes, start.Add(time.Second))
+	signal, ok := slow.sample(start.Add(3 * time.Second))
+	if !ok || signal.reason != "sustained-low-throughput" {
+		t.Fatalf("slow transfer did not produce expected signal: ok=%v signal=%s", ok, signal)
+	}
+
+	healthy := &smartMonitoredConn{}
+	healthy.observeTotals(smartMonitorMinUploadBytes, 0, start)
+	healthy.observeTotals(smartMonitorMinUploadBytes, 128*1024, start.Add(time.Second))
+	if signal, ok := healthy.sample(start.Add(3 * time.Second)); ok {
+		t.Fatalf("healthy transfer produced signal: %s", signal)
+	}
+}
+
+func TestSmartActiveDegradationRejectsRepeatedEvidenceFromSameConnection(t *testing.T) {
+	s := &Smart{}
+	conn := &smartMonitoredConn{}
+	now := time.Unix(300, 0)
+	const key = "node\x00*.example.com"
+
+	if s.recordActiveDegradationEvidence(key, conn, 1, "sustained-low-throughput", now) {
+		t.Fatal("first observation confirmed degradation")
+	}
+	if s.recordActiveDegradationEvidence(key, conn, 1, "sustained-low-throughput", now.Add(time.Second)) {
+		t.Fatal("duplicate observation confirmed degradation")
+	}
+	if s.recordActiveDegradationEvidence(key, conn, 2, "sustained-low-throughput", now.Add(2*time.Second)) {
+		t.Fatal("same connection confirmed degradation")
+	}
+	conn.closed = true
+	if !s.recordActiveDegradationEvidence(key, &smartMonitoredConn{}, 1, "sustained-low-throughput", now.Add(3*time.Second)) {
+		t.Fatal("closed prior connection and distinct new connection did not confirm degradation")
+	}
+}
+
+func TestSmartActiveDegradationEvidenceExpires(t *testing.T) {
+	s := &Smart{}
+	conn := &smartMonitoredConn{}
+	now := time.Unix(400, 0)
+	const key = "node\x00*.example.com"
+
+	if s.recordActiveDegradationEvidence(key, conn, 1, "no-response-after-write", now) {
+		t.Fatal("first observation confirmed degradation")
+	}
+	if s.recordActiveDegradationEvidence(key, conn, 2, "no-response-after-write", now.Add(smartMonitorEvidenceWindow+time.Second)) {
+		t.Fatal("expired evidence confirmed degradation")
+	}
+}
+
+func TestSmartActiveDegradationDoesNotConfirmNoResponseEvidence(t *testing.T) {
+	s := &Smart{}
+	first := &smartMonitoredConn{}
+	second := &smartMonitoredConn{}
+	now := time.Unix(450, 0)
+	const key = "node\x00*.example.com"
+
+	if s.recordActiveDegradationEvidence(key, first, 1, "no-response-after-write", now) {
+		t.Fatal("first no-response observation confirmed degradation")
+	}
+	if s.recordActiveDegradationEvidence(key, second, 1, "no-response-after-write", now.Add(time.Second)) {
+		t.Fatal("concurrent no-response connection confirmed degradation")
+	}
+	first.closed = true
+	if s.recordActiveDegradationEvidence(key, second, 1, "no-response-after-write", now.Add(2*time.Second)) {
+		t.Fatal("no-response evidence confirmed degradation")
+	}
+}
+
+func TestSmartActiveDegradationCooldownIsScopedByNodeAndWildcard(t *testing.T) {
+	s := &Smart{}
+	now := time.Unix(500, 0)
+	key := "node-a\x00*.example.com"
+	s.activeMonitor.evidence = map[string]smartDegradationEvidence{
+		key: {confirmedUntil: now.Add(smartMonitorCooldown)},
+	}
+
+	if !s.activeNodeCoolingDown("node-a", "*.example.com", now) {
+		t.Fatal("confirmed node and wildcard were not cooling down")
+	}
+	if s.activeNodeCoolingDown("node-b", "*.example.com", now) {
+		t.Fatal("cooldown leaked to another node")
+	}
+	if s.activeNodeCoolingDown("node-a", "*.other.example", now) {
+		t.Fatal("cooldown leaked to another wildcard")
+	}
+	if s.activeNodeCoolingDown("node-a", "*.example.com", now.Add(smartMonitorCooldown)) {
+		t.Fatal("expired cooldown remained active")
+	}
+}

--- a/adapter/outboundgroup/smart_observability.go
+++ b/adapter/outboundgroup/smart_observability.go
@@ -1,0 +1,108 @@
+package outboundgroup
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/metacubex/mihomo/log"
+)
+
+const smartTimingUnobserved = "unobserved"
+
+var smartTimingSequence atomic.Uint64
+
+type smartTimingEvent struct {
+	phase                    string
+	streamReadyElapsed       time.Duration
+	firstWriteToRead         time.Duration
+	firstWriteToReadObserved bool
+	err                      error
+}
+
+type smartConnectionTiming struct {
+	traceID       string
+	group         string
+	node          string
+	target        string
+	wildcard      string
+	proxyConnect  time.Duration
+	streamReadyAt time.Time
+	firstWriteAt  atomic.Int64
+}
+
+func newSmartConnectionTiming(group, node, target, wildcard string, proxyConnect time.Duration, streamReadyAt time.Time) *smartConnectionTiming {
+	return &smartConnectionTiming{
+		traceID:       fmt.Sprintf("%x-%x", streamReadyAt.UnixNano(), smartTimingSequence.Add(1)),
+		group:         group,
+		node:          node,
+		target:        target,
+		wildcard:      wildcard,
+		proxyConnect:  proxyConnect,
+		streamReadyAt: streamReadyAt,
+	}
+}
+
+func (t *smartConnectionTiming) firstWriteEvent(now time.Time, err error) smartTimingEvent {
+	t.firstWriteAt.CompareAndSwap(0, now.UnixNano())
+	return smartTimingEvent{
+		phase:              "first-write",
+		streamReadyElapsed: now.Sub(t.streamReadyAt),
+		err:                err,
+	}
+}
+
+func (t *smartConnectionTiming) firstReadEvent(now time.Time, err error) smartTimingEvent {
+	event := smartTimingEvent{
+		phase:              "first-read",
+		streamReadyElapsed: now.Sub(t.streamReadyAt),
+		err:                err,
+	}
+	if firstWriteAt := t.firstWriteAt.Load(); firstWriteAt != 0 {
+		event.firstWriteToRead = now.Sub(time.Unix(0, firstWriteAt))
+		event.firstWriteToReadObserved = true
+	}
+	return event
+}
+
+func (t *smartConnectionTiming) logEvent(event smartTimingEvent) {
+	firstWriteToRead := smartTimingUnobserved
+	if event.firstWriteToReadObserved {
+		firstWriteToRead = formatTimeUnit(float64(event.firstWriteToRead.Milliseconds()))
+	}
+	log.Debugln("[SmartTiming] phase=[%s] trace=[%s] group=[%s] node=[%s] target=[%s] wildcard=[%s] proxy-connect=[%s] stream-ready-elapsed=[%s] first-write-to-read=[%s] error=[%s]",
+		event.phase,
+		t.traceID,
+		t.group,
+		t.node,
+		t.target,
+		t.wildcard,
+		formatTimeUnit(float64(t.proxyConnect.Milliseconds())),
+		formatTimeUnit(float64(event.streamReadyElapsed.Milliseconds())),
+		firstWriteToRead,
+		formatSmartTimingError(event.err),
+	)
+}
+
+func (t *smartConnectionTiming) logClose(now time.Time, connectionID string, connectionDuration int64, uploadTotal, downloadTotal int64) {
+	log.Debugln("[SmartTiming] phase=[close] trace=[%s] id=[%s] group=[%s] node=[%s] target=[%s] wildcard=[%s] proxy-connect=[%s] stream-lifetime=[%s] tracker-duration=[%s] up=[%s] down=[%s]",
+		t.traceID,
+		connectionID,
+		t.group,
+		t.node,
+		t.target,
+		t.wildcard,
+		formatTimeUnit(float64(t.proxyConnect.Milliseconds())),
+		formatTimeUnit(float64(now.Sub(t.streamReadyAt).Milliseconds())),
+		formatTimeUnit(float64(connectionDuration)),
+		formatTrafficUnit(float64(uploadTotal), false),
+		formatTrafficUnit(float64(downloadTotal), false),
+	)
+}
+
+func formatSmartTimingError(err error) string {
+	if err == nil {
+		return "none"
+	}
+	return fmt.Sprintf("%v", err)
+}

--- a/adapter/outboundgroup/smart_observability_test.go
+++ b/adapter/outboundgroup/smart_observability_test.go
@@ -1,0 +1,67 @@
+package outboundgroup
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestSmartConnectionTimingSeparatesProxyWriteAndReadPhases(t *testing.T) {
+	base := time.Unix(1_000, 0)
+	trace := newSmartConnectionTiming(
+		"smart-group",
+		"node-a",
+		"GeoSite [github]",
+		"*.github.com",
+		321*time.Millisecond,
+		base,
+	)
+
+	write := trace.firstWriteEvent(base.Add(25*time.Millisecond), nil)
+	if write.phase != "first-write" {
+		t.Fatalf("write phase = %q, want first-write", write.phase)
+	}
+	if write.streamReadyElapsed != 25*time.Millisecond {
+		t.Fatalf("write elapsed = %s, want 25ms", write.streamReadyElapsed)
+	}
+	if write.firstWriteToReadObserved {
+		t.Fatal("first-write event must not claim a write-to-read duration")
+	}
+
+	read := trace.firstReadEvent(base.Add(425*time.Millisecond), nil)
+	if read.phase != "first-read" {
+		t.Fatalf("read phase = %q, want first-read", read.phase)
+	}
+	if read.streamReadyElapsed != 425*time.Millisecond {
+		t.Fatalf("read elapsed = %s, want 425ms", read.streamReadyElapsed)
+	}
+	if !read.firstWriteToReadObserved {
+		t.Fatal("first-read event must observe the preceding first write")
+	}
+	if read.firstWriteToRead != 400*time.Millisecond {
+		t.Fatalf("write-to-read = %s, want 400ms", read.firstWriteToRead)
+	}
+	if trace.traceID == "" {
+		t.Fatal("trace id must be available before the tracker id")
+	}
+}
+
+func TestSmartConnectionTimingReportsMissingFirstWriteExplicitly(t *testing.T) {
+	base := time.Unix(2_000, 0)
+	trace := newSmartConnectionTiming("group", "node", "target", "wildcard", 50*time.Millisecond, base)
+	wantErr := errors.New("read failed")
+
+	read := trace.firstReadEvent(base.Add(100*time.Millisecond), wantErr)
+	if read.firstWriteToReadObserved {
+		t.Fatal("read without first write must remain explicitly unobserved")
+	}
+	if !errors.Is(read.err, wantErr) {
+		t.Fatalf("read error = %v, want %v", read.err, wantErr)
+	}
+	if got := formatSmartTimingError(nil); got != "none" {
+		t.Fatalf("nil error label = %q, want none", got)
+	}
+	if got := formatSmartTimingError(wantErr); got != wantErr.Error() {
+		t.Fatalf("error label = %q, want %q", got, wantErr.Error())
+	}
+}

--- a/adapter/outboundgroup/smart_selection.go
+++ b/adapter/outboundgroup/smart_selection.go
@@ -1,0 +1,155 @@
+package outboundgroup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/metacubex/mihomo/component/smart"
+	C "github.com/metacubex/mihomo/constant"
+)
+
+var errSmartSelectionMissingWinner = errors.New("smart selection completed without a winner")
+
+type smartProxySelectionState struct {
+	key          string
+	cacheHit     bool
+	cacheExpired bool
+	fixed        bool
+}
+
+type smartDialSelection struct {
+	proxies       []C.Proxy
+	asnNumber     string
+	persistWinner bool
+	flightKey     string
+	flight        *smartSelectionFlight
+	leader        bool
+}
+
+func shouldRecordSmartDialFailure(ctx context.Context, err error) bool {
+	return err != nil && !errors.Is(err, context.Canceled) && ctx.Err() == nil
+}
+
+func smartStatusProbeAccepted(status uint16, ok bool) bool {
+	if ok {
+		return true
+	}
+	// StatusTest probes an arbitrary host root rather than the original request
+	// path. A 403/405 response proves the proxy completed TCP, TLS, and HTTP; many
+	// CDN roots intentionally return these statuses, so they cannot identify a
+	// failed proxy node.
+	return status == 403 || status == 405
+}
+
+type smartSelectionFlight struct {
+	done   chan struct{}
+	winner string
+	err    error
+}
+
+type smartSelectionCoordinator struct {
+	mu      sync.Mutex
+	flights map[string]*smartSelectionFlight
+}
+
+func smartSelectionFlightKey(config, group, target string) string {
+	// StoreUnwrapResult persists one winner per config/group/SmartTarget. The
+	// in-flight key must use the same identity: ASN can differ between parallel
+	// connections before DNS/CDN metadata settles, but those calls still share
+	// the target-level winner.
+	return smart.FormatDBKey(config, group, target)
+}
+
+func smartDialBatchBounds(total, iteration int, leader bool) (int, int) {
+	if total <= 0 || iteration < 0 {
+		return 0, 0
+	}
+	if total == 1 {
+		if iteration == 0 {
+			return 0, 1
+		}
+		return 0, 0
+	}
+	if leader {
+		// There is exactly one leader per target, so racing the complete bounded
+		// candidate set avoids making every follower inherit a slow first-node
+		// timeout while still publishing only one successful winner.
+		if iteration == 0 {
+			return 0, total
+		}
+		return 0, 0
+	}
+	if iteration == 0 {
+		return 0, 1
+	}
+
+	begin := 1 + (iteration-1)*parallelDials
+	if begin >= total {
+		return 0, 0
+	}
+	end := begin + parallelDials
+	if end > total {
+		end = total
+	}
+	return begin, end
+}
+
+func (c *smartSelectionCoordinator) begin(key string) (*smartSelectionFlight, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.flights == nil {
+		c.flights = make(map[string]*smartSelectionFlight)
+	}
+	if flight, found := c.flights[key]; found {
+		return flight, false
+	}
+
+	flight := &smartSelectionFlight{done: make(chan struct{})}
+	c.flights[key] = flight
+	return flight, true
+}
+
+func (c *smartSelectionCoordinator) finish(key string, flight *smartSelectionFlight, winner string, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	current, found := c.flights[key]
+	if !found || current != flight {
+		return
+	}
+	if err == nil && winner == "" {
+		err = errSmartSelectionMissingWinner
+	}
+
+	flight.winner = winner
+	flight.err = err
+	delete(c.flights, key)
+	close(flight.done)
+}
+
+func (f *smartSelectionFlight) wait(ctx context.Context) (string, error) {
+	select {
+	case <-f.done:
+		if f.err != nil {
+			return "", f.err
+		}
+		if f.winner == "" {
+			return "", errSmartSelectionMissingWinner
+		}
+		return f.winner, nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+func findSmartProxyByName(proxies []C.Proxy, name string) (C.Proxy, error) {
+	for _, proxy := range proxies {
+		if proxy.Name() == name {
+			return proxy, nil
+		}
+	}
+	return nil, fmt.Errorf("smart selection winner unavailable: %s", name)
+}

--- a/adapter/outboundgroup/smart_selection_test.go
+++ b/adapter/outboundgroup/smart_selection_test.go
@@ -1,0 +1,179 @@
+package outboundgroup
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSmartSelectionFlightKeyMatchesTargetCacheIdentity(t *testing.T) {
+	const (
+		config = "config"
+		group  = "smart-group"
+		target = "GeoSite [geolocation-!cn]"
+	)
+
+	got := smartSelectionFlightKey(config, group, target)
+	want := "smart/config/smart-group/GeoSite [geolocation-!cn]"
+	if got != want {
+		t.Fatalf("smartSelectionFlightKey() = %q, want %q", got, want)
+	}
+}
+
+func TestSmartDialBatchBoundsLeaderRacesAllCandidatesOnce(t *testing.T) {
+	begin, end := smartDialBatchBounds(10, 0, true)
+	if begin != 0 || end != 10 {
+		t.Fatalf("leader first batch = [%d:%d], want [0:10]", begin, end)
+	}
+	begin, end = smartDialBatchBounds(10, 1, true)
+	if begin != 0 || end != 0 {
+		t.Fatalf("leader second batch = [%d:%d], want empty", begin, end)
+	}
+}
+
+func TestSmartDialBatchBoundsCachedPathKeepsBoundedRetries(t *testing.T) {
+	tests := []struct {
+		iteration int
+		begin     int
+		end       int
+	}{
+		{iteration: 0, begin: 0, end: 1},
+		{iteration: 1, begin: 1, end: 6},
+		{iteration: 2, begin: 6, end: 10},
+	}
+	for _, test := range tests {
+		begin, end := smartDialBatchBounds(10, test.iteration, false)
+		if begin != test.begin || end != test.end {
+			t.Fatalf("iteration %d batch = [%d:%d], want [%d:%d]", test.iteration, begin, end, test.begin, test.end)
+		}
+	}
+}
+
+func TestShouldRecordSmartDialFailureIgnoresCanceledRaceLoser(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if shouldRecordSmartDialFailure(ctx, errors.New("transport returned after race cancellation")) {
+		t.Fatal("canceled race loser must not be recorded as a node failure")
+	}
+	if !shouldRecordSmartDialFailure(context.Background(), errors.New("real dial failure")) {
+		t.Fatal("live-context dial failure must be recorded")
+	}
+}
+
+func TestSmartStatusProbeAcceptedTreatsEndpointPolicyAsReachable(t *testing.T) {
+	for _, status := range []uint16{403, 405} {
+		if !smartStatusProbeAccepted(status, false) {
+			t.Fatalf("status %d must prove the proxy path is reachable", status)
+		}
+	}
+	if smartStatusProbeAccepted(503, false) {
+		t.Fatal("status 503 must remain an abnormal probe response")
+	}
+	if !smartStatusProbeAccepted(204, true) {
+		t.Fatal("StatusTest success must remain accepted")
+	}
+}
+
+func TestSmartSelectionCoordinatorPublishesOneWinner(t *testing.T) {
+	var coordinator smartSelectionCoordinator
+	const callers = 64
+
+	start := make(chan struct{})
+	results := make(chan string, callers)
+	errs := make(chan error, callers)
+	var leaders atomic.Int64
+	var wg sync.WaitGroup
+
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			flight, leader := coordinator.begin("config/group/target")
+			if leader {
+				leaders.Add(1)
+				time.Sleep(10 * time.Millisecond)
+				coordinator.finish("config/group/target", flight, "winner", nil)
+				results <- "winner"
+				return
+			}
+
+			winner, err := flight.wait(context.Background())
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- winner
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	if got := leaders.Load(); got != 1 {
+		t.Fatalf("leaders = %d, want 1", got)
+	}
+	for err := range errs {
+		t.Fatalf("wait error: %v", err)
+	}
+	count := 0
+	for result := range results {
+		count++
+		if result != "winner" {
+			t.Fatalf("winner = %q, want winner", result)
+		}
+	}
+	if count != callers {
+		t.Fatalf("results = %d, want %d", count, callers)
+	}
+}
+
+func TestSmartSelectionCoordinatorPropagatesFailure(t *testing.T) {
+	var coordinator smartSelectionCoordinator
+	flight, leader := coordinator.begin("target")
+	if !leader {
+		t.Fatal("first caller must be leader")
+	}
+
+	wantErr := errors.New("selection failed")
+	coordinator.finish("target", flight, "", wantErr)
+	if _, err := flight.wait(context.Background()); !errors.Is(err, wantErr) {
+		t.Fatalf("wait error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestSmartSelectionCoordinatorRejectsMissingWinner(t *testing.T) {
+	var coordinator smartSelectionCoordinator
+	flight, leader := coordinator.begin("target")
+	if !leader {
+		t.Fatal("first caller must be leader")
+	}
+
+	coordinator.finish("target", flight, "", nil)
+	if _, err := flight.wait(context.Background()); !errors.Is(err, errSmartSelectionMissingWinner) {
+		t.Fatalf("wait error = %v, want %v", err, errSmartSelectionMissingWinner)
+	}
+}
+
+func TestSmartSelectionCoordinatorWaitHonorsContext(t *testing.T) {
+	var coordinator smartSelectionCoordinator
+	flight, leader := coordinator.begin("target")
+	if !leader {
+		t.Fatal("first caller must be leader")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := flight.wait(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("wait error = %v, want context canceled", err)
+	}
+
+	coordinator.finish("target", flight, "winner", nil)
+}


### PR DESCRIPTION
## Severity: this breaks the Smart selection model

This is not merely connection cleanup. It turns Smart from a quality-learning, continuity-preserving selector into a latest-success-wins connection rotator.

Smart stores an unwrap result so later connections to the same `SmartTarget` can reuse the learned selection. But every successful TCP or UDP dial also calls `closeSameConnection(..., false)`. Any active connection for that target using a different proxy is closed even though no degradation was observed.

Normal web pages create many concurrent connections. If those dials complete through different candidates, every later completion invalidates earlier successful traffic:

1. Smart establishes healthy traffic through proxy A.
2. A concurrent dial completes through proxy B.
3. Success on B closes the healthy connection on A.
4. The client retries, potentially selecting another proxy and closing more traffic.

This self-induced churn destroys Smart connection continuity and makes it behave like rapid proxy rotation rather than stable learned selection. It applies to every concurrent Smart target, not only Pinterest. Symptoms include TLS `unexpected EOF`, interrupted transfers, reconnect storms, and browsers shifting toward QUIC after TCP is repeatedly destroyed.

## Reproduction

On an isolated iStoreOS 24.10.8 x86_64 router, 15 concurrent Pinterest HTTPS requests produced:

- Smart: 1 success, 13 TLS `unexpected EOF`, 1 timeout
- Fixed stable proxy: 15/15 success
- Fixed degraded proxy: 10/15 success, 5 ordinary timeouts, no TLS EOF

These controls separate node quality from Smart-generated churn.

## Change

Remove success-path sibling cleanup for TCP and UDP. Smart still stores unwrap results and records metrics. Forced cleanup remains unchanged: `closeSameConnection(..., true)` runs only after measured degradation or host-failure evidence.

## Verification

With the same Smart configuration and pool, four bursts totaling 60 Pinterest requests produced:

- 60/60 completed TLS and received HTTP 200
- 59/60 completed within 15 seconds
- 1/60 timed out after receiving about 914 KB
- 0 TLS `unexpected EOF`

The final burst had 15 matching controller TCP logs. The same code was then deployed on ARM64 OpenWrt: Smart remained loaded, takeover stayed effective, and a five-request live check completed 5/5 with HTTP 200 and no EOF.

## Tests

- `go test ./adapter/outboundgroup ./component/smart ./tunnel/statistic`
- `go test ./...`
- `git diff --check`